### PR TITLE
charges: handle fuzz crash

### DIFF
--- a/charges.go
+++ b/charges.go
@@ -6,6 +6,7 @@ package wire
 
 import (
 	"strings"
+	"unicode/utf8"
 )
 
 // Charges is the Charges of the wire
@@ -50,6 +51,9 @@ func NewCharges() *Charges {
 // Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm
 // successful parsing and data validity.
 func (c *Charges) Parse(record string) {
+	if utf8.RuneCountInString(record) < 67 {
+		return // line too short
+	}
 	c.tag = record[:6]
 	c.ChargeDetails = c.parseStringField(record[6:7])
 	c.SendersChargesOne = c.parseStringField(record[7:22])

--- a/charges_test.go
+++ b/charges_test.go
@@ -34,3 +34,15 @@ func TestPaymentNotificationIndicatorValid(t *testing.T) {
 		}
 	}
 }
+
+func TestChargesCrash(t *testing.T) {
+	c := &Charges{}
+	c.Parse("{3700}") // invalid, caused a fuzz crash
+
+	if c.tag != "" {
+		t.Errorf("c.tag=%s", c.tag)
+	}
+	if c.ChargeDetails != "" {
+		t.Errorf("unexpected c.ChargeDetails=%s", c.ChargeDetails)
+	}
+}


### PR DESCRIPTION
```
panic: runtime error: slice bounds out of range

goroutine 1 [running]:
github.com/moov-io/wire.(*Charges).Parse(0xc00008e1c0, 0xc00001a100, 0x6)
	/go/src/github.com/moov-io/wire/charges.go:54 +0x29d
github.com/moov-io/wire.(*Reader).parseCharges(0xc000041a70, 0x6, 0x60a7ef)
	/go/src/github.com/moov-io/wire/reader.go:470 +0xa4
```