### PR TITLE
cmd/server: bind HTTP server with TLS if HTTPS_* variables are defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ $ go doc github.com/moov-io/wire fedWireMessage
 
 | Environmental Variable | Description | Default |
 |-----|-----|-----|
+| `HTTPS_CERT_FILE` | Filepath containing a certificate (or intermediate chain) to be served by the HTTP server. Requires all traffic be over secure HTTP. | Empty |
+| `HTTPS_KEY_FILE`  | Filepath of a private key matching the leaf certificate from `HTTPS_CERT_FILE`. | Empty |
 | `WIRE_FILE_TTL` | Time to live (TTL) for `*wire.File` objects stored in the in-memory repository. | 0 = No TTL / Never delete files (Example: `240m`) |
 
 Note: By design Wire **does not persist** (save) any data about the files, batches or entry details created. The only storage occurs in memory of the process and upon restart Wire will have no files, batches, or data saved. Also, no in memory encryption of the data is performed.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -102,10 +102,17 @@ func main() {
 
 	// Start business logic HTTP server
 	go func() {
-		logger.Log("transport", "HTTP", "addr", *httpAddr)
-		errs <- serve.ListenAndServe()
-		// TODO(adam): support TLS
-		// func (srv *Server) ListenAndServeTLS(certFile, keyFile string) error
+		if certFile, keyFile := os.Getenv("HTTPS_CERT_FILE"), os.Getenv("HTTPS_KEY_FILE"); certFile != "" && keyFile != "" {
+			logger.Log("startup", fmt.Sprintf("binding to %s for secure HTTP server", *httpAddr))
+			if err := serve.ListenAndServeTLS(certFile, keyFile); err != nil {
+				logger.Log("exit", err)
+			}
+		} else {
+			logger.Log("startup", fmt.Sprintf("binding to %s for secure HTTP server", *httpAddr))
+			if err := serve.ListenAndServe(); err != nil {
+				logger.Log("exit", err)
+			}
+		}
 	}()
 
 	// Block/Wait for an error


### PR DESCRIPTION
Fixes: https://github.com/moov-io/wire/issues/54