### PR TITLE
all: populate record tag after JSON unmarshal

### DIFF
--- a/accountCreditedDrawdown.go
+++ b/accountCreditedDrawdown.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -40,6 +41,20 @@ func (creditDD *AccountCreditedDrawdown) Parse(record string) error {
 	}
 	creditDD.tag = record[:6]
 	creditDD.DrawdownCreditAccountNumber = creditDD.parseStringField(record[6:15])
+	return nil
+}
+
+func (creditDD *AccountCreditedDrawdown) UnmarshalJSON(data []byte) error {
+	type Alias AccountCreditedDrawdown
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(creditDD),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	creditDD.tag = TagAccountCreditedDrawdown
 	return nil
 }
 

--- a/accountDebitedDrawdown.go
+++ b/accountDebitedDrawdown.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -50,6 +51,20 @@ func (debitDD *AccountDebitedDrawdown) Parse(record string) error {
 	debitDD.Address.AddressLineOne = debitDD.parseStringField(record[76:111])
 	debitDD.Address.AddressLineTwo = debitDD.parseStringField(record[111:146])
 	debitDD.Address.AddressLineThree = debitDD.parseStringField(record[146:181])
+	return nil
+}
+
+func (debitDD *AccountDebitedDrawdown) UnmarshalJSON(data []byte) error {
+	type Alias AccountDebitedDrawdown
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(debitDD),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	debitDD.tag = TagAccountDebitedDrawdown
 	return nil
 }
 

--- a/actualAmountPaid.go
+++ b/actualAmountPaid.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -41,6 +42,20 @@ func (aap *ActualAmountPaid) Parse(record string) error {
 	aap.tag = record[:6]
 	aap.RemittanceAmount.CurrencyCode = aap.parseStringField(record[6:9])
 	aap.RemittanceAmount.Amount = aap.parseStringField(record[9:28])
+	return nil
+}
+
+func (aap *ActualAmountPaid) UnmarshalJSON(data []byte) error {
+	type Alias ActualAmountPaid
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(aap),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	aap.tag = TagActualAmountPaid
 	return nil
 }
 

--- a/adjustment.go
+++ b/adjustment.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -50,6 +51,20 @@ func (adj *Adjustment) Parse(record string) error {
 	adj.RemittanceAmount.CurrencyCode = adj.parseStringField(record[12:15])
 	adj.RemittanceAmount.Amount = adj.parseStringField(record[15:34])
 	adj.AdditionalInfo = adj.parseStringField(record[34:174])
+	return nil
+}
+
+func (adj *Adjustment) UnmarshalJSON(data []byte) error {
+	type Alias Adjustment
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(adj),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	adj.tag = TagAdjustment
 	return nil
 }
 

--- a/amount.go
+++ b/amount.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -40,6 +41,20 @@ func (a *Amount) Parse(record string) error {
 	}
 	a.tag = record[:6]
 	a.Amount = a.parseStringField(record[6:18])
+	return nil
+}
+
+func (a *Amount) UnmarshalJSON(data []byte) error {
+	type Alias Amount
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(a),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	a.tag = TagAmount
 	return nil
 }
 

--- a/amountNegotiatedDiscount.go
+++ b/amountNegotiatedDiscount.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -41,6 +42,20 @@ func (nd *AmountNegotiatedDiscount) Parse(record string) error {
 	nd.tag = record[:6]
 	nd.RemittanceAmount.CurrencyCode = nd.parseStringField(record[6:9])
 	nd.RemittanceAmount.Amount = nd.parseStringField(record[9:28])
+	return nil
+}
+
+func (nd *AmountNegotiatedDiscount) UnmarshalJSON(data []byte) error {
+	type Alias AmountNegotiatedDiscount
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(nd),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	nd.tag = TagAmountNegotiatedDiscount
 	return nil
 }
 

--- a/beneficiary.go
+++ b/beneficiary.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -45,6 +46,20 @@ func (ben *Beneficiary) Parse(record string) error {
 	ben.Personal.Address.AddressLineOne = ben.parseStringField(record[76:111])
 	ben.Personal.Address.AddressLineTwo = ben.parseStringField(record[111:146])
 	ben.Personal.Address.AddressLineThree = ben.parseStringField(record[146:181])
+	return nil
+}
+
+func (ben *Beneficiary) UnmarshalJSON(data []byte) error {
+	type Alias Beneficiary
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(ben),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	ben.tag = TagBeneficiary
 	return nil
 }
 

--- a/beneficiaryCustomer.go
+++ b/beneficiaryCustomer.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -45,6 +46,20 @@ func (bc *BeneficiaryCustomer) Parse(record string) error {
 	bc.CoverPayment.SwiftLineThree = bc.parseStringField(record[81:116])
 	bc.CoverPayment.SwiftLineFour = bc.parseStringField(record[116:151])
 	bc.CoverPayment.SwiftLineFive = bc.parseStringField(record[151:186])
+	return nil
+}
+
+func (bc *BeneficiaryCustomer) UnmarshalJSON(data []byte) error {
+	type Alias BeneficiaryCustomer
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(bc),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	bc.tag = TagBeneficiaryCustomer
 	return nil
 }
 

--- a/beneficiaryFI.go
+++ b/beneficiaryFI.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -45,6 +46,20 @@ func (bfi *BeneficiaryFI) Parse(record string) error {
 	bfi.FinancialInstitution.Address.AddressLineOne = bfi.parseStringField(record[76:111])
 	bfi.FinancialInstitution.Address.AddressLineTwo = bfi.parseStringField(record[111:146])
 	bfi.FinancialInstitution.Address.AddressLineThree = bfi.parseStringField(record[146:181])
+	return nil
+}
+
+func (bfi *BeneficiaryFI) UnmarshalJSON(data []byte) error {
+	type Alias BeneficiaryFI
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(bfi),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	bfi.tag = TagBeneficiaryFI
 	return nil
 }
 

--- a/beneficiaryIntermediaryFI.go
+++ b/beneficiaryIntermediaryFI.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -45,6 +46,20 @@ func (bifi *BeneficiaryIntermediaryFI) Parse(record string) error {
 	bifi.FinancialInstitution.Address.AddressLineOne = bifi.parseStringField(record[76:111])
 	bifi.FinancialInstitution.Address.AddressLineTwo = bifi.parseStringField(record[111:146])
 	bifi.FinancialInstitution.Address.AddressLineThree = bifi.parseStringField(record[146:181])
+	return nil
+}
+
+func (bifi *BeneficiaryIntermediaryFI) UnmarshalJSON(data []byte) error {
+	type Alias BeneficiaryIntermediaryFI
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(bifi),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	bifi.tag = TagBeneficiaryIntermediaryFI
 	return nil
 }
 

--- a/beneficiaryReference.go
+++ b/beneficiaryReference.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -40,6 +41,20 @@ func (br *BeneficiaryReference) Parse(record string) error {
 	}
 	br.tag = record[:6]
 	br.BeneficiaryReference = br.parseStringField(record[6:22])
+	return nil
+}
+
+func (br *BeneficiaryReference) UnmarshalJSON(data []byte) error {
+	type Alias BeneficiaryReference
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(br),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	br.tag = TagBeneficiaryReference
 	return nil
 }
 

--- a/businessFunctionCode.go
+++ b/businessFunctionCode.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -43,6 +44,20 @@ func (bfc *BusinessFunctionCode) Parse(record string) error {
 	bfc.tag = record[:6]
 	bfc.BusinessFunctionCode = bfc.parseStringField(record[6:9])
 	bfc.TransactionTypeCode = record[9:12]
+	return nil
+}
+
+func (bfc *BusinessFunctionCode) UnmarshalJSON(data []byte) error {
+	type Alias BusinessFunctionCode
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(bfc),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	bfc.tag = TagBusinessFunctionCode
 	return nil
 }
 

--- a/charges.go
+++ b/charges.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -60,6 +61,20 @@ func (c *Charges) Parse(record string) {
 	c.SendersChargesTwo = c.parseStringField(record[22:37])
 	c.SendersChargesThree = c.parseStringField(record[37:52])
 	c.SendersChargesFour = c.parseStringField(record[52:67])
+}
+
+func (c *Charges) UnmarshalJSON(data []byte) error {
+	type Alias Charges
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(c),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	c.tag = TagCharges
+	return nil
 }
 
 // String writes Charges

--- a/currencyInstructedAmount.go
+++ b/currencyInstructedAmount.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -44,6 +45,20 @@ func (cia *CurrencyInstructedAmount) Parse(record string) error {
 	cia.tag = record[:6]
 	cia.SwiftFieldTag = cia.parseStringField(record[6:11])
 	cia.Amount = cia.parseStringField(record[11:29])
+	return nil
+}
+
+func (cia *CurrencyInstructedAmount) UnmarshalJSON(data []byte) error {
+	type Alias CurrencyInstructedAmount
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(cia),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	cia.tag = TagCurrencyInstructedAmount
 	return nil
 }
 

--- a/dateRemittanceDocument.go
+++ b/dateRemittanceDocument.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -40,6 +41,20 @@ func (drd *DateRemittanceDocument) Parse(record string) error {
 	}
 	drd.tag = record[:6]
 	drd.DateRemittanceDocument = drd.parseStringField(record[6:14])
+	return nil
+}
+
+func (drd *DateRemittanceDocument) UnmarshalJSON(data []byte) error {
+	type Alias DateRemittanceDocument
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(drd),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	drd.tag = TagDateRemittanceDocument
 	return nil
 }
 

--- a/errorWire.go
+++ b/errorWire.go
@@ -4,7 +4,10 @@
 
 package wire
 
-import "strings"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // ErrorWire is a wire error with the fedwire message
 type ErrorWire struct {
@@ -40,6 +43,20 @@ func (ew *ErrorWire) Parse(record string) {
 	ew.ErrorCategory = ew.parseStringField(record[6:7])
 	ew.ErrorCode = ew.parseStringField(record[7:10])
 	ew.ErrorDescription = ew.parseStringField(record[10:45])
+}
+
+func (ew *ErrorWire) UnmarshalJSON(data []byte) error {
+	type Alias ErrorWire
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(ew),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	ew.tag = TagErrorWire
+	return nil
 }
 
 // String writes ErrorWire

--- a/exchangeRate.go
+++ b/exchangeRate.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -41,6 +42,20 @@ func (eRate *ExchangeRate) Parse(record string) error {
 	}
 	eRate.tag = record[:6]
 	eRate.ExchangeRate = eRate.parseStringField(record[6:18])
+	return nil
+}
+
+func (eRate *ExchangeRate) UnmarshalJSON(data []byte) error {
+	type Alias ExchangeRate
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(eRate),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	eRate.tag = TagExchangeRate
 	return nil
 }
 

--- a/fIBeneficiaryFIAdvice.go
+++ b/fIBeneficiaryFIAdvice.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -46,6 +47,20 @@ func (fibfia *FIBeneficiaryFIAdvice) Parse(record string) error {
 	fibfia.Advice.LineFour = fibfia.parseStringField(record[101:134])
 	fibfia.Advice.LineFive = fibfia.parseStringField(record[134:167])
 	fibfia.Advice.LineSix = fibfia.parseStringField(record[167:200])
+	return nil
+}
+
+func (fibfia *FIBeneficiaryFIAdvice) UnmarshalJSON(data []byte) error {
+	type Alias FIBeneficiaryFIAdvice
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(fibfia),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	fibfia.tag = TagFIBeneficiaryFIAdvice
 	return nil
 }
 

--- a/fiAdditionalFIToFI.go
+++ b/fiAdditionalFIToFI.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -45,6 +46,20 @@ func (fifi *FIAdditionalFIToFI) Parse(record string) error {
 	fifi.AdditionalFIToFI.LineFour = fifi.parseStringField(record[111:146])
 	fifi.AdditionalFIToFI.LineFive = fifi.parseStringField(record[146:181])
 	fifi.AdditionalFIToFI.LineSix = fifi.parseStringField(record[181:216])
+	return nil
+}
+
+func (fifi *FIAdditionalFIToFI) UnmarshalJSON(data []byte) error {
+	type Alias FIAdditionalFIToFI
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(fifi),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	fifi.tag = TagFIAdditionalFIToFI
 	return nil
 }
 

--- a/fiBeneficiary.go
+++ b/fiBeneficiary.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -45,6 +46,20 @@ func (fib *FIBeneficiary) Parse(record string) error {
 	fib.FIToFI.LineFour = fib.parseStringField(record[102:135])
 	fib.FIToFI.LineFive = fib.parseStringField(record[135:168])
 	fib.FIToFI.LineSix = fib.parseStringField(record[168:201])
+	return nil
+}
+
+func (fib *FIBeneficiary) UnmarshalJSON(data []byte) error {
+	type Alias FIBeneficiary
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(fib),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	fib.tag = TagFIBeneficiary
 	return nil
 }
 

--- a/fiBeneficiaryAdvice.go
+++ b/fiBeneficiaryAdvice.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -46,6 +47,20 @@ func (fiba *FIBeneficiaryAdvice) Parse(record string) error {
 	fiba.Advice.LineFour = fiba.parseStringField(record[101:134])
 	fiba.Advice.LineFive = fiba.parseStringField(record[134:167])
 	fiba.Advice.LineSix = fiba.parseStringField(record[167:200])
+	return nil
+}
+
+func (fiba *FIBeneficiaryAdvice) UnmarshalJSON(data []byte) error {
+	type Alias FIBeneficiaryAdvice
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(fiba),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	fiba.tag = TagFIBeneficiaryAdvice
 	return nil
 }
 

--- a/fiBeneficiaryFI.go
+++ b/fiBeneficiaryFI.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -45,6 +46,20 @@ func (fibfi *FIBeneficiaryFI) Parse(record string) error {
 	fibfi.FIToFI.LineFour = fibfi.parseStringField(record[102:135])
 	fibfi.FIToFI.LineFive = fibfi.parseStringField(record[135:168])
 	fibfi.FIToFI.LineSix = fibfi.parseStringField(record[168:201])
+	return nil
+}
+
+func (fibfi *FIBeneficiaryFI) UnmarshalJSON(data []byte) error {
+	type Alias FIBeneficiaryFI
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(fibfi),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	fibfi.tag = TagFIBeneficiaryFI
 	return nil
 }
 

--- a/fiDrawdownDebitAccountAdvice.go
+++ b/fiDrawdownDebitAccountAdvice.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -46,6 +47,20 @@ func (debitDDAdvice *FIDrawdownDebitAccountAdvice) Parse(record string) error {
 	debitDDAdvice.Advice.LineFour = debitDDAdvice.parseStringField(record[101:134])
 	debitDDAdvice.Advice.LineFive = debitDDAdvice.parseStringField(record[134:167])
 	debitDDAdvice.Advice.LineSix = debitDDAdvice.parseStringField(record[167:200])
+	return nil
+}
+
+func (debitDDAdvice *FIDrawdownDebitAccountAdvice) UnmarshalJSON(data []byte) error {
+	type Alias FIDrawdownDebitAccountAdvice
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(debitDDAdvice),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	debitDDAdvice.tag = TagFIDrawdownDebitAccountAdvice
 	return nil
 }
 

--- a/fiIntermediaryFI.go
+++ b/fiIntermediaryFI.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -45,6 +46,20 @@ func (fiifi *FIIntermediaryFI) Parse(record string) error {
 	fiifi.FIToFI.LineFour = fiifi.parseStringField(record[102:135])
 	fiifi.FIToFI.LineFive = fiifi.parseStringField(record[135:168])
 	fiifi.FIToFI.LineSix = fiifi.parseStringField(record[168:201])
+	return nil
+}
+
+func (fiifi *FIIntermediaryFI) UnmarshalJSON(data []byte) error {
+	type Alias FIIntermediaryFI
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(fiifi),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	fiifi.tag = TagFIIntermediaryFI
 	return nil
 }
 

--- a/fiIntermediaryFIAdvice.go
+++ b/fiIntermediaryFIAdvice.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -46,6 +47,20 @@ func (fiifia *FIIntermediaryFIAdvice) Parse(record string) error {
 	fiifia.Advice.LineFour = fiifia.parseStringField(record[101:134])
 	fiifia.Advice.LineFive = fiifia.parseStringField(record[134:167])
 	fiifia.Advice.LineSix = fiifia.parseStringField(record[167:200])
+	return nil
+}
+
+func (fiifia *FIIntermediaryFIAdvice) UnmarshalJSON(data []byte) error {
+	type Alias FIIntermediaryFIAdvice
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(fiifia),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	fiifia.tag = TagFIIntermediaryFIAdvice
 	return nil
 }
 

--- a/fiPaymentMethodToBeneficiary.go
+++ b/fiPaymentMethodToBeneficiary.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -44,6 +45,20 @@ func (pm *FIPaymentMethodToBeneficiary) Parse(record string) error {
 	pm.tag = record[:6]
 	pm.PaymentMethod = pm.parseStringField(record[6:11])
 	pm.AdditionalInformation = pm.parseStringField(record[11:41])
+	return nil
+}
+
+func (pm *FIPaymentMethodToBeneficiary) UnmarshalJSON(data []byte) error {
+	type Alias FIPaymentMethodToBeneficiary
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(pm),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	pm.tag = TagFIPaymentMethodToBeneficiary
 	return nil
 }
 

--- a/fiReceiverFI.go
+++ b/fiReceiverFI.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -45,6 +46,20 @@ func (firfi *FIReceiverFI) Parse(record string) error {
 	firfi.FIToFI.LineFour = firfi.parseStringField(record[102:135])
 	firfi.FIToFI.LineFive = firfi.parseStringField(record[135:168])
 	firfi.FIToFI.LineSix = firfi.parseStringField(record[174:201])
+	return nil
+}
+
+func (firfi *FIReceiverFI) UnmarshalJSON(data []byte) error {
+	type Alias FIReceiverFI
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(firfi),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	firfi.tag = TagFIReceiverFI
 	return nil
 }
 

--- a/grossAmountRemittanceDocument.go
+++ b/grossAmountRemittanceDocument.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -41,6 +42,20 @@ func (gard *GrossAmountRemittanceDocument) Parse(record string) error {
 	gard.tag = record[:6]
 	gard.RemittanceAmount.CurrencyCode = gard.parseStringField(record[6:9])
 	gard.RemittanceAmount.Amount = gard.parseStringField(record[9:28])
+	return nil
+}
+
+func (gard *GrossAmountRemittanceDocument) UnmarshalJSON(data []byte) error {
+	type Alias GrossAmountRemittanceDocument
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(gard),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	gard.tag = TagGrossAmountRemittanceDocument
 	return nil
 }
 

--- a/inputMessageAccountabilityData.go
+++ b/inputMessageAccountabilityData.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -46,6 +47,20 @@ func (imad *InputMessageAccountabilityData) Parse(record string) error {
 	imad.InputCycleDate = imad.parseStringField(record[6:14])
 	imad.InputSource = imad.parseStringField(record[14:22])
 	imad.InputSequenceNumber = imad.parseStringField(record[22:28])
+	return nil
+}
+
+func (imad *InputMessageAccountabilityData) UnmarshalJSON(data []byte) error {
+	type Alias InputMessageAccountabilityData
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(imad),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	imad.tag = TagInputMessageAccountabilityData
 	return nil
 }
 

--- a/institutionAccount.go
+++ b/institutionAccount.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -45,6 +46,20 @@ func (iAccount *InstitutionAccount) Parse(record string) error {
 	iAccount.CoverPayment.SwiftLineThree = iAccount.parseStringField(record[81:116])
 	iAccount.CoverPayment.SwiftLineFour = iAccount.parseStringField(record[116:151])
 	iAccount.CoverPayment.SwiftLineFive = iAccount.parseStringField(record[151:186])
+	return nil
+}
+
+func (iAccount *InstitutionAccount) UnmarshalJSON(data []byte) error {
+	type Alias InstitutionAccount
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(iAccount),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	iAccount.tag = TagInstitutionAccount
 	return nil
 }
 

--- a/instructedAmount.go
+++ b/instructedAmount.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -44,6 +45,20 @@ func (ia *InstructedAmount) Parse(record string) error {
 	ia.tag = record[:6]
 	ia.CurrencyCode = ia.parseStringField(record[6:9])
 	ia.Amount = ia.parseStringField(record[9:24])
+	return nil
+}
+
+func (ia *InstructedAmount) UnmarshalJSON(data []byte) error {
+	type Alias InstructedAmount
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(ia),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	ia.tag = TagInstructedAmount
 	return nil
 }
 

--- a/instructingFI.go
+++ b/instructingFI.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -45,6 +46,20 @@ func (ifi *InstructingFI) Parse(record string) error {
 	ifi.FinancialInstitution.Address.AddressLineOne = ifi.parseStringField(record[76:111])
 	ifi.FinancialInstitution.Address.AddressLineTwo = ifi.parseStringField(record[111:146])
 	ifi.FinancialInstitution.Address.AddressLineThree = ifi.parseStringField(record[146:181])
+	return nil
+}
+
+func (ifi *InstructingFI) UnmarshalJSON(data []byte) error {
+	type Alias InstructingFI
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(ifi),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	ifi.tag = TagInstructingFI
 	return nil
 }
 

--- a/intermediaryInstitution.go
+++ b/intermediaryInstitution.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -45,6 +46,20 @@ func (ii *IntermediaryInstitution) Parse(record string) error {
 	ii.CoverPayment.SwiftLineThree = ii.parseStringField(record[81:116])
 	ii.CoverPayment.SwiftLineFour = ii.parseStringField(record[116:151])
 	ii.CoverPayment.SwiftLineFive = ii.parseStringField(record[151:186])
+	return nil
+}
+
+func (ii *IntermediaryInstitution) UnmarshalJSON(data []byte) error {
+	type Alias IntermediaryInstitution
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(ii),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	ii.tag = TagIntermediaryInstitution
 	return nil
 }
 

--- a/issue104_test.go
+++ b/issue104_test.go
@@ -1,0 +1,50 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"bytes"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIssue104(t *testing.T) {
+	bs, err := ioutil.ReadFile(filepath.Join("test", "testdata", "fedWireMessage-BankTransfer.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	file, err := FileFromJSON(bs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if file == nil {
+		t.Fatal("nil File")
+	}
+
+	var buf bytes.Buffer
+	if err := NewWriter(&buf).Write(file); err != nil {
+		t.Fatal(err)
+	}
+
+	// verify the output
+	lines := strings.Split(buf.String(), "\n")
+	if n := len(lines); n != 27 {
+		t.Errorf("got %d lines", n)
+	}
+	for i := range lines {
+		if lines[i] == "" {
+			continue
+		}
+
+		prefix := string(lines[i][0:6])
+		// tags are 4 digits surrounded by {..} - example: {1500}
+		if prefix[0] != '{' || prefix[5] != '}' {
+			t.Errorf("index #%d - missing tag: %q", i, prefix)
+		}
+	}
+}

--- a/localInstrument.go
+++ b/localInstrument.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -43,6 +44,20 @@ func (li *LocalInstrument) Parse(record string) error {
 	li.tag = record[:6]
 	li.LocalInstrumentCode = li.parseStringField(record[6:10])
 	li.ProprietaryCode = li.parseStringField(record[10:45])
+	return nil
+}
+
+func (li *LocalInstrument) UnmarshalJSON(data []byte) error {
+	type Alias LocalInstrument
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(li),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	li.tag = TagLocalInstrument
 	return nil
 }
 

--- a/messageDisposition.go
+++ b/messageDisposition.go
@@ -4,7 +4,10 @@
 
 package wire
 
-import "strings"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // MessageDisposition is the message disposition of the wire
 type MessageDisposition struct {
@@ -46,6 +49,20 @@ func (md *MessageDisposition) Parse(record string) {
 	md.TestProductionCode = md.parseStringField(record[8:9])
 	md.MessageDuplicationCode = md.parseStringField(record[9:10])
 	md.MessageStatusIndicator = md.parseStringField(record[10:11])
+}
+
+func (md *MessageDisposition) UnmarshalJSON(data []byte) error {
+	type Alias MessageDisposition
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(md),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	md.tag = TagMessageDisposition
+	return nil
 }
 
 // String writes MessageDisposition

--- a/orderingCustomer.go
+++ b/orderingCustomer.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -45,6 +46,20 @@ func (oc *OrderingCustomer) Parse(record string) error {
 	oc.CoverPayment.SwiftLineThree = oc.parseStringField(record[81:116])
 	oc.CoverPayment.SwiftLineFour = oc.parseStringField(record[116:151])
 	oc.CoverPayment.SwiftLineFive = oc.parseStringField(record[151:186])
+	return nil
+}
+
+func (oc *OrderingCustomer) UnmarshalJSON(data []byte) error {
+	type Alias OrderingCustomer
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(oc),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	oc.tag = TagOrderingCustomer
 	return nil
 }
 

--- a/orderingInstitution.go
+++ b/orderingInstitution.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -45,6 +46,20 @@ func (oi *OrderingInstitution) Parse(record string) error {
 	oi.CoverPayment.SwiftLineThree = oi.parseStringField(record[81:116])
 	oi.CoverPayment.SwiftLineFour = oi.parseStringField(record[116:151])
 	oi.CoverPayment.SwiftLineFive = oi.parseStringField(record[151:186])
+	return nil
+}
+
+func (oi *OrderingInstitution) UnmarshalJSON(data []byte) error {
+	type Alias OrderingInstitution
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(oi),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	oi.tag = TagOrderingInstitution
 	return nil
 }
 

--- a/originator.go
+++ b/originator.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -44,6 +45,20 @@ func (o *Originator) Parse(record string) error {
 	o.Personal.Name = o.parseStringField(record[41:76])
 	o.Personal.Address.AddressLineOne = o.parseStringField(record[76:111])
 	o.Personal.Address.AddressLineThree = o.parseStringField(record[146:181])
+	return nil
+}
+
+func (o *Originator) UnmarshalJSON(data []byte) error {
+	type Alias Originator
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(o),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	o.tag = TagOriginator
 	return nil
 }
 

--- a/originatorFI.go
+++ b/originatorFI.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -45,6 +46,20 @@ func (ofi *OriginatorFI) Parse(record string) error {
 	ofi.FinancialInstitution.Address.AddressLineOne = ofi.parseStringField(record[76:111])
 	ofi.FinancialInstitution.Address.AddressLineTwo = ofi.parseStringField(record[111:146])
 	ofi.FinancialInstitution.Address.AddressLineThree = ofi.parseStringField(record[146:181])
+	return nil
+}
+
+func (ofi *OriginatorFI) UnmarshalJSON(data []byte) error {
+	type Alias OriginatorFI
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(ofi),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	ofi.tag = TagOriginatorFI
 	return nil
 }
 

--- a/originatorOptionF.go
+++ b/originatorOptionF.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -108,6 +109,20 @@ func (oof *OriginatorOptionF) Parse(record string) error {
 	oof.LineOne = oof.parseStringField(record[76:111])
 	oof.LineTwo = oof.parseStringField(record[111:146])
 	oof.LineThree = oof.parseStringField(record[146:181])
+	return nil
+}
+
+func (oof *OriginatorOptionF) UnmarshalJSON(data []byte) error {
+	type Alias OriginatorOptionF
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(oof),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	oof.tag = TagOriginatorOptionF
 	return nil
 }
 

--- a/originatorToBeneficiary.go
+++ b/originatorToBeneficiary.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -49,6 +50,20 @@ func (ob *OriginatorToBeneficiary) Parse(record string) error {
 	ob.LineTwo = ob.parseStringField(record[41:76])
 	ob.LineThree = ob.parseStringField(record[76:111])
 	ob.LineFour = ob.parseStringField(record[111:146])
+	return nil
+}
+
+func (ob *OriginatorToBeneficiary) UnmarshalJSON(data []byte) error {
+	type Alias OriginatorToBeneficiary
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(ob),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	ob.tag = TagOriginatorToBeneficiary
 	return nil
 }
 

--- a/outputMessageAccountabilityData.go
+++ b/outputMessageAccountabilityData.go
@@ -4,7 +4,10 @@
 
 package wire
 
-import "strings"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // OutputMessageAccountabilityData is the Output Message Accountability Data (OMAD) of the wire
 type OutputMessageAccountabilityData struct {
@@ -49,6 +52,20 @@ func (omad *OutputMessageAccountabilityData) Parse(record string) {
 	omad.OutputDate = omad.parseStringField(record[28:32])
 	omad.OutputTime = omad.parseStringField(record[32:36])
 	omad.OutputFRBApplicationIdentification = omad.parseStringField(record[36:40])
+}
+
+func (omad *OutputMessageAccountabilityData) UnmarshalJSON(data []byte) error {
+	type Alias OutputMessageAccountabilityData
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(omad),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	omad.tag = TagOutputMessageAccountabilityData
+	return nil
 }
 
 // String writes OutputMessageAccountabilityData

--- a/paymentNotification.go
+++ b/paymentNotification.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -60,6 +61,20 @@ func (pn *PaymentNotification) Parse(record string) error {
 	pn.ContactMobileNumber = pn.parseStringField(record[2230:2265])
 	pn.ContactFaxNumber = pn.parseStringField(record[2265:2300])
 	pn.EndToEndIdentification = pn.parseStringField(record[2300:2335])
+	return nil
+}
+
+func (pn *PaymentNotification) UnmarshalJSON(data []byte) error {
+	type Alias PaymentNotification
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(pn),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	pn.tag = TagPaymentNotification
 	return nil
 }
 

--- a/previousMessageIdentifier.go
+++ b/previousMessageIdentifier.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -40,6 +41,20 @@ func (pmi *PreviousMessageIdentifier) Parse(record string) error {
 	}
 	pmi.tag = record[:6]
 	pmi.PreviousMessageIdentifier = pmi.parseStringField(record[6:28])
+	return nil
+}
+
+func (pmi *PreviousMessageIdentifier) UnmarshalJSON(data []byte) error {
+	type Alias PreviousMessageIdentifier
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(pmi),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	pmi.tag = TagPreviousMessageIdentifier
 	return nil
 }
 

--- a/primaryRemittanceDocument.go
+++ b/primaryRemittanceDocument.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -49,6 +50,20 @@ func (prd *PrimaryRemittanceDocument) Parse(record string) error {
 	prd.ProprietaryDocumentTypeCode = record[10:45]
 	prd.DocumentIdentificationNumber = record[45:80]
 	prd.Issuer = record[80:115]
+	return nil
+}
+
+func (prd *PrimaryRemittanceDocument) UnmarshalJSON(data []byte) error {
+	type Alias PrimaryRemittanceDocument
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(prd),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	prd.tag = TagPrimaryRemittanceDocument
 	return nil
 }
 

--- a/receiptTimeStamp.go
+++ b/receiptTimeStamp.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -47,6 +48,20 @@ func (rts *ReceiptTimeStamp) Parse(record string) error {
 	rts.ReceiptDate = rts.parseStringField(record[6:10])
 	rts.ReceiptTime = rts.parseStringField(record[10:14])
 	rts.ReceiptApplicationIdentification = rts.parseStringField(record[14:18])
+	return nil
+}
+
+func (rts *ReceiptTimeStamp) UnmarshalJSON(data []byte) error {
+	type Alias ReceiptTimeStamp
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(rts),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	rts.tag = TagReceiptTimeStamp
 	return nil
 }
 

--- a/receiverDepositoryInstitution.go
+++ b/receiverDepositoryInstitution.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -43,6 +44,20 @@ func (rdi *ReceiverDepositoryInstitution) Parse(record string) error {
 	rdi.tag = record[:6]
 	rdi.ReceiverABANumber = rdi.parseStringField(record[6:15])
 	rdi.ReceiverShortName = rdi.parseStringField(record[15:33])
+	return nil
+}
+
+func (rdi *ReceiverDepositoryInstitution) UnmarshalJSON(data []byte) error {
+	type Alias ReceiverDepositoryInstitution
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(rdi),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	rdi.tag = TagReceiverDepositoryInstitution
 	return nil
 }
 

--- a/relatedRemittance.go
+++ b/relatedRemittance.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -65,6 +66,20 @@ func (rr *RelatedRemittance) Parse(record string) error {
 	rr.RemittanceData.AddressLineFive = rr.parseStringField(record[2831:2901])
 	rr.RemittanceData.AddressLineSix = rr.parseStringField(record[2901:2971])
 	rr.RemittanceData.AddressLineSeven = rr.parseStringField(record[2971:3041])
+	return nil
+}
+
+func (rr *RelatedRemittance) UnmarshalJSON(data []byte) error {
+	type Alias RelatedRemittance
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(rr),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	rr.tag = TagRelatedRemittance
 	return nil
 }
 

--- a/remittance.go
+++ b/remittance.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -44,6 +45,20 @@ func (ri *Remittance) Parse(record string) error {
 	ri.CoverPayment.SwiftLineTwo = ri.parseStringField(record[46:81])
 	ri.CoverPayment.SwiftLineThree = ri.parseStringField(record[81:116])
 	ri.CoverPayment.SwiftLineFour = ri.parseStringField(record[116:151])
+	return nil
+}
+
+func (ri *Remittance) UnmarshalJSON(data []byte) error {
+	type Alias Remittance
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(ri),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	ri.tag = TagRemittance
 	return nil
 }
 

--- a/remittanceBeneficiary.go
+++ b/remittanceBeneficiary.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -70,6 +71,20 @@ func (rb *RemittanceBeneficiary) Parse(record string) error {
 	rb.RemittanceData.AddressLineSix = rb.parseStringField(record[972:1042])
 	rb.RemittanceData.AddressLineSeven = rb.parseStringField(record[1042:1112])
 	rb.RemittanceData.CountryOfResidence = rb.parseStringField(record[1112:1114])
+	return nil
+}
+
+func (rb *RemittanceBeneficiary) UnmarshalJSON(data []byte) error {
+	type Alias RemittanceBeneficiary
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(rb),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	rb.tag = TagRemittanceBeneficiary
 	return nil
 }
 

--- a/remittanceFreeText.go
+++ b/remittanceFreeText.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -46,6 +47,20 @@ func (rft *RemittanceFreeText) Parse(record string) error {
 	rft.LineOne = rft.parseStringField(record[6:146])
 	rft.LineTwo = rft.parseStringField(record[146:286])
 	rft.LineThree = rft.parseStringField(record[286:426])
+	return nil
+}
+
+func (rft *RemittanceFreeText) UnmarshalJSON(data []byte) error {
+	type Alias RemittanceFreeText
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(rft),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	rft.tag = TagRemittanceFreeText
 	return nil
 }
 

--- a/remittanceOriginator.go
+++ b/remittanceOriginator.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -88,6 +89,20 @@ func (ro *RemittanceOriginator) Parse(record string) error {
 	ro.ContactFaxNumber = ro.parseStringField(record[1324:1359])
 	ro.ContactElectronicAddress = ro.parseStringField(record[1359:3407])
 	ro.ContactOther = ro.parseStringField(record[3407:3442])
+	return nil
+}
+
+func (ro *RemittanceOriginator) UnmarshalJSON(data []byte) error {
+	type Alias RemittanceOriginator
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(ro),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	ro.tag = TagRemittanceOriginator
 	return nil
 }
 

--- a/secondaryRemittanceDocument.go
+++ b/secondaryRemittanceDocument.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -49,6 +50,20 @@ func (srd *SecondaryRemittanceDocument) Parse(record string) error {
 	srd.ProprietaryDocumentTypeCode = srd.parseStringField(record[10:45])
 	srd.DocumentIdentificationNumber = srd.parseStringField(record[45:80])
 	srd.Issuer = srd.parseStringField(record[80:115])
+	return nil
+}
+
+func (srd *SecondaryRemittanceDocument) UnmarshalJSON(data []byte) error {
+	type Alias SecondaryRemittanceDocument
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(srd),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	srd.tag = TagSecondaryRemittanceDocument
 	return nil
 }
 

--- a/senderDepositoryInstitution.go
+++ b/senderDepositoryInstitution.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -44,6 +45,20 @@ func (sdi *SenderDepositoryInstitution) Parse(record string) error {
 	sdi.tag = record[:6]
 	sdi.SenderABANumber = sdi.parseStringField(record[6:15])
 	sdi.SenderShortName = sdi.parseStringField(record[15:33])
+	return nil
+}
+
+func (sdi *SenderDepositoryInstitution) UnmarshalJSON(data []byte) error {
+	type Alias SenderDepositoryInstitution
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(sdi),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	sdi.tag = TagSenderDepositoryInstitution
 	return nil
 }
 

--- a/senderReference.go
+++ b/senderReference.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -40,6 +41,20 @@ func (sr *SenderReference) Parse(record string) error {
 	}
 	sr.tag = record[:6]
 	sr.SenderReference = record[6:22]
+	return nil
+}
+
+func (sr *SenderReference) UnmarshalJSON(data []byte) error {
+	type Alias SenderReference
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(sr),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	sr.tag = TagSenderReference
 	return nil
 }
 

--- a/senderSupplied.go
+++ b/senderSupplied.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -52,6 +53,20 @@ func (ss *SenderSupplied) Parse(record string) error {
 	ss.UserRequestCorrelation = ss.parseStringField(record[8:16])
 	ss.TestProductionCode = ss.parseStringField(record[16:17])
 	ss.MessageDuplicationCode = ss.parseStringField(record[17:18])
+	return nil
+}
+
+func (ss *SenderSupplied) UnmarshalJSON(data []byte) error {
+	type Alias SenderSupplied
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(ss),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	ss.tag = TagSenderSupplied
 	return nil
 }
 

--- a/senderToReceiver.go
+++ b/senderToReceiver.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -46,6 +47,20 @@ func (str *SenderToReceiver) Parse(record string) error {
 	str.CoverPayment.SwiftLineFour = str.parseStringField(record[116:151])
 	str.CoverPayment.SwiftLineFive = str.parseStringField(record[151:186])
 	str.CoverPayment.SwiftLineSix = str.parseStringField(record[186:221])
+	return nil
+}
+
+func (str *SenderToReceiver) UnmarshalJSON(data []byte) error {
+	type Alias SenderToReceiver
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(str),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	str.tag = TagSenderToReceiver
 	return nil
 }
 

--- a/serviceMessage.go
+++ b/serviceMessage.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -73,6 +74,20 @@ func (sm *ServiceMessage) Parse(record string) error {
 	sm.LineTen = sm.parseStringField(record[321:356])
 	sm.LineEleven = sm.parseStringField(record[356:391])
 	sm.LineTwelve = sm.parseStringField(record[391:426])
+	return nil
+}
+
+func (sm *ServiceMessage) UnmarshalJSON(data []byte) error {
+	type Alias ServiceMessage
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(sm),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	sm.tag = TagServiceMessage
 	return nil
 }
 

--- a/typeSubType.go
+++ b/typeSubType.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -43,6 +44,20 @@ func (tst *TypeSubType) Parse(record string) error {
 	tst.tag = tst.parseStringField(record[:6])
 	tst.TypeCode = tst.parseStringField(record[6:8])
 	tst.SubTypeCode = tst.parseStringField(record[8:10])
+	return nil
+}
+
+func (tst *TypeSubType) UnmarshalJSON(data []byte) error {
+	type Alias TypeSubType
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(tst),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	tst.tag = TagTypeSubType
 	return nil
 }
 

--- a/unstructuredAddenda.go
+++ b/unstructuredAddenda.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -49,6 +50,20 @@ func (ua *UnstructuredAddenda) Parse(record string) error {
 		return NewTagWrongLengthErr(10+al, utf8.RuneCountInString(record))
 	}
 	ua.Addenda = ua.parseStringField(record[10 : 10+al])
+	return nil
+}
+
+func (ua *UnstructuredAddenda) UnmarshalJSON(data []byte) error {
+	type Alias UnstructuredAddenda
+	aux := struct {
+		*Alias
+	}{
+		(*Alias)(ua),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	ua.tag = TagUnstructuredAddenda
 	return nil
 }
 


### PR DESCRIPTION
Due to the way Go initializes structs their fields cannot have a
default value. This means we use exported constructors to populate
them with hidden fields. When we unmarshal (via FileFromJSON) those
hidden files are not populated, so we have to sneak their values in
whenever someone uses json.Unmarshaler

Fixes: https://github.com/moov-io/wire/issues/104