### PR TITLE
install git in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.15-alpine as builder
 WORKDIR /go/src/github.com/moov-io/wire
-RUN apk add -U make bash gcc
+RUN apk add -U --no-cache make bash gcc git
 RUN adduser -D -g '' --shell /bin/false moov
 COPY . .
 RUN make build


### PR DESCRIPTION
`git` commands and commands that execute `git` commands (e.g. `go get`) are failing because the `golang:1.15-alpine` image doesn't include `git`.