### PR TITLE
fedWireMessage: read and write fed appended tags

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -94,6 +94,22 @@ func (r *Reader) parseLine() error { //nolint:gocyclo
 		return fmt.Errorf("line %q is too short for tag", r.line)
 	}
 	switch r.line[:6] {
+	case TagMessageDisposition:
+		if err := r.parseMessageDisposition(); err != nil {
+			return err
+		}
+	case TagReceiptTimeStamp:
+		if err := r.parseReceiptTimeStamp(); err != nil {
+			return err
+		}
+	case TagOutputMessageAccountabilityData:
+		if err := r.parseOutputMessageAccountabilityData(); err != nil {
+			return err
+		}
+	case TagErrorWire:
+		if err := r.parseErrorWire(); err != nil {
+			return err
+		}
 	case TagSenderSupplied:
 		if err := r.parseSenderSupplied(); err != nil {
 			return err
@@ -1065,7 +1081,9 @@ func (r *Reader) parseMessageDisposition() error {
 func (r *Reader) parseReceiptTimeStamp() error {
 	r.tagName = "ReceiptTimeStamp"
 	rts := new(ReceiptTimeStamp)
-	rts.Parse(r.line)
+	if err := rts.Parse(r.line); err != nil {
+		return r.parseError(err)
+	}
 	if err := rts.Validate(); err != nil {
 		return r.parseError(err)
 	}

--- a/reader_test.go
+++ b/reader_test.go
@@ -26,6 +26,7 @@ func TestRead(t *testing.T) {
 	t.Run("CustomerTransferPlusCOVS", testRead(filepath.Join("test", "testdata", "fedWireMessage-CustomerTransferPlusCOVS.txt")))
 	t.Run("CustomerTransferPlusUnstructuredAddenda", testRead(filepath.Join("test", "testdata", "fedWireMessage-CustomerTransferPlusUnstructuredAddenda.txt")))
 	t.Run("CustomerTransferPlusStructuredRemittance", testRead(filepath.Join("test", "testdata", "fedWireMessage-CustomerTransferPlusStructuredRemittance.txt")))
+	t.Run("FedAppendedTags", testRead(filepath.Join("test", "testdata", "fedWireMessage-FedAppendedTags.txt")))
 }
 
 func testRead(filePathName string) func(t *testing.T) {

--- a/test/testdata/fedWireMessage-FedAppendedTags.txt
+++ b/test/testdata/fedWireMessage-FedAppendedTags.txt
@@ -1,0 +1,30 @@
+{1500}30User ReqT 
+{1510}1000
+{1520}20190410Source08000001
+{2000}000001234567
+{3100}121042882Wells Fargo NA    
+{3400}231380104Citadel           
+{3600}BTR   
+{3320}Sender Reference
+{3500}Previous Message Ident
+{4000}D123456789                         FI Name                            Address One                        Address Two                        Address Three                      
+{4100}D123456789                         FI Name                            Address One                        Address Two                        Address Three                      
+{4200}31234                              Name                               Address One                        Address Two                        Address Three                      
+{4320}Reference       
+{5000}11234                              Name                               Address One                        Address Two                        Address Three                      
+{5100}D123456789                         FI Name                            Address One                        Address Two                        Address Three                      
+{5200}D123456789                         FI Name                            Address One                        Address Two                        Address Three                      
+{6000}LineOne                            LineTwo                            LineThree                          LineFour                           
+{6100}Line Six                                                                                                                                                                                           
+{6200}Line Six                                                                                                                                                                                           
+{6210}LTRLine One                  Line Two                         Line Three                       Line Four                        Line Five                        Line Six                         
+{6300}Line One                      Line Two                         Line Three                       Line Four                        Line Five                        Line Six                         
+{6310}TLXLine One                  Line Two                         Line Three                       Line Four                        Line Five                        Line Six                         
+{6400}Line One                      Line Two                         Line Three                       Line Four                        Line Five                        Line Six                         
+{6410}LTRLine One                  Line Two                         Line Three                       Line Four                        Line Five                        Line Six                         
+{6420}CHECKAdditional Information        
+{6500}Line One                           Line Two                           Line Three                         Line Four                          Line Five                          Line Six                           
+{1100}30P 2
+{1110}05021230A123
+{1120}20190502Source0800000105021230B123
+{1130}EXYZData Error                         

--- a/writer.go
+++ b/writer.go
@@ -85,27 +85,35 @@ func (w *Writer) writeFEDWireMessage(file *File) error {
 		}
 	}
 
-	// Information Appended by FedWire Funds Service - Commented for now
-	/*	if fwm.MessageDisposition != nil {
+	if err := w.writeFedAppended(fwm); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (w *Writer) writeFedAppended(fwm FEDWireMessage) error {
+	if fwm.MessageDisposition != nil {
 		if _, err := w.w.WriteString(fwm.MessageDisposition.String() + "\n"); err != nil {
 			return err
 		}
-	}*/
-	/*	if fwm.ReceiptTimeStamp != nil {
+	}
+	if fwm.ReceiptTimeStamp != nil {
 		if _, err := w.w.WriteString(fwm.ReceiptTimeStamp.String() + "\n"); err != nil {
 			return err
 		}
-	}*/
-	/*	if fwm.OutputMessageAccountabilityData != nil {
+	}
+	if fwm.OutputMessageAccountabilityData != nil {
 		if _, err := w.w.WriteString(fwm.OutputMessageAccountabilityData.String() + "\n"); err != nil {
 			return err
 		}
-	}*/
-	/*	if fwm.ErrorWire != nil {
+	}
+	if fwm.ErrorWire != nil {
 		if _, err := w.w.WriteString(fwm.ErrorWire.String() + "\n"); err != nil {
 			return err
 		}
-	}*/
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
As part of their file processing, the Fedwire Funds Service will append tags to a message before delivering the file to the depository institution. The Wire library already included the models, parsing, and validation logic for these tags, but they weren't included in the reader or writer. This PR adds the following tags to the reader and writer:
* `{1100}` Message Disposition
* `{1110}` Receipt Time Stamp
* `{1120}` Output Message Accountability Data (OMAD)
* `{1130}` Error

Closes #109 