### PR TITLE
fix #207:make IMAD field optional for fedline advantage customers

### DIFF
--- a/fedWireMessage.go
+++ b/fedWireMessage.go
@@ -131,6 +131,13 @@ type FEDWireMessage struct {
 	RemittanceFreeText *RemittanceFreeText `json:"remittanceFreeText,omitempty"`
 	// ServiceMessage
 	ServiceMessage *ServiceMessage `json:"serviceMessage,omitempty"`
+
+	validateOpts *ValidateOpts
+}
+
+type ValidateOpts struct {
+	// AllowMissingIMAD allows a file to be created or read without the InputMessageAccountabilityData tag
+	AllowMissingIMAD bool `json:"allowMissingIMAD"`
 }
 
 // verify checks basic WIRE rules. Assumes properly parsed records. Each validation func should
@@ -239,9 +246,9 @@ func (fwm *FEDWireMessage) validateTypeSubType() error {
 }
 
 // validateIMAD validates TagInputMessageAccountabilityData within a FEDWireMessage
-// Mandatory for all requests
+// Mandatory for all requests unless sender is a FedLine Advantage customer
 func (fwm *FEDWireMessage) validateIMAD() error {
-	if fwm.InputMessageAccountabilityData == nil {
+	if fwm.InputMessageAccountabilityData == nil && fwm.validateOpts.AllowMissingIMAD == false {
 		return fieldError("InputMessageAccountabilityData", ErrFieldRequired)
 	}
 	return nil

--- a/fedWiremessage_test.go
+++ b/fedWiremessage_test.go
@@ -1185,3 +1185,12 @@ func TestInvalidAccountCreditedDrawdownForCustomerTransferPlus(t *testing.T) {
 	expected := fieldError("AccountCreditedDrawdown", ErrInvalidProperty, fwm.AccountCreditedDrawdown).Error()
 	require.EqualError(t, err, expected)
 }
+
+func TestFEDWireMessage_missingIMAD_isFedLineAdvantageCustomer(t *testing.T) {
+	fwm := mockCustomerTransferData()
+	fwm.InputMessageAccountabilityData = nil
+	// InputMessageAccountabilityData is optional if the sender is a FedLine Advantage customer
+	fwm.validateOpts.AllowMissingIMAD = true
+	err := fwm.validateIMAD()
+	require.NoError(t, err)
+}

--- a/writer.go
+++ b/writer.go
@@ -137,7 +137,7 @@ func (w *Writer) writeMandatory(fwm FEDWireMessage) error {
 		if _, err := w.w.WriteString(fwm.InputMessageAccountabilityData.String() + "\n"); err != nil {
 			return err
 		}
-	} else {
+	} else if fwm.validateOpts.AllowMissingIMAD == false { // IMAD is optional for FedLine Advantage customers
 		return fieldError("InputMessageAccountabilityData", ErrFieldRequired)
 	}
 	if fwm.Amount != nil {


### PR DESCRIPTION
The Fedwire spec states that the `Input Message Accountability Data (IMAD)` field is optional for FedLine Advantage import customers.
This MR adds an `IsFedLineAdvantageCustomer` (bool) field to the `FEDWireMessage` struct which, if set to true, will allow the IMAD field to be omitted during fedwire file creation