### PR TITLE
amount: update validation to ensure value is numeric

### DIFF
--- a/amount.go
+++ b/amount.go
@@ -14,7 +14,10 @@ import (
 type Amount struct {
 	// tag
 	tag string
-	// Amount 12 numeric, right-justified with leading zeros, an implied decimal point and no commas; e.g., $12,345.67 becomes 000001234567 Can be all zeros for subtype 90
+
+	// Amount must be right justified with leading zeroes, an implied decimal point and
+	// no commas (e.g., $12,345.67 becomes 000001234567). Amount can be all zeroes for
+	// only SUBTYPE CODE 90 messages.
 	Amount string `json:"amount"`
 
 	// validator is composed for data validation

--- a/validators.go
+++ b/validators.go
@@ -42,7 +42,7 @@ func (v *validator) isNumeric(s string) error {
 
 // ToDo: Amount Decimal and AmountComma (only 1 per each) ?
 
-// isAmount checks if a string only contains onc comma and ASCII numeric (0-9) characters
+// isAmount checks if a string only contains one comma and ASCII numeric (0-9) characters
 func (v *validator) isAmount(s string) error {
 	str := strings.Trim(s, ",")
 	if amountRegex.MatchString(str) {
@@ -52,20 +52,10 @@ func (v *validator) isAmount(s string) error {
 	return nil
 }
 
-/*// isAmount checks if a string only contains onc decmal and ASCII numeric (0-9) characters
-func (v *validator) isAmountDecimal(s string) error {
-	str := strings.Trim(s, ".")
-	if amountRegex.MatchString(str) {
-		// [^ [0-9],.]
-		return ErrNonAmount
-	}
-	return nil
-}*/
-
-// isAmountImplied checks if a string only contains only ASCII numeric (0-9) characters, decimal precision is
+// isAmountImplied checks if a string contains only ASCII numeric (0-9) characters, decimal precision is
 // implied (2), and no commas
 func (v *validator) isAmountImplied(s string) error {
-	if amountRegex.MatchString(s) {
+	if numericRegex.MatchString(s) {
 		// [^ 0-9]
 		return ErrNonAmount
 	}


### PR DESCRIPTION
This update ensures the Amount in tag `{2000}` only contains numbers. The 3.0.7 specification says 
> The amount can be up to a penny less than 10 billion ($9,999,999,999.99). 
The amount must be right justified with leading zeroes, an implied decimal
 point and no commas (e.g., $12,345.67 becomes 000001234567). The 
amount can be all zeroes for only SUBTYPE CODE 90 messages.

Closes #220 