### PR TITLE
Fix: Add Equality Sign to Converters

### DIFF
--- a/converters.go
+++ b/converters.go
@@ -84,7 +84,7 @@ func (c *converters) parseVariableStringField(r string, maxLen int) (got string,
 
 	hasDelimiter := false
 	size = min(endIndex, delimiterIndex)
-	if size > maxLen {
+	if size >= maxLen {
 		size = maxLen
 	} else if size < maxLen {
 		if delimiterIndex == size {


### PR DESCRIPTION
Adds an equal sign to account for when the values are the same. Since the logic makes the value the same as 'size' the case is already covered in existing test cases. 