### PR TITLE
Fix: add equality sign to converters when size is equal to maxLen

### DIFF
--- a/converters.go
+++ b/converters.go
@@ -93,7 +93,7 @@ func (c *converters) parseVariableStringField(r string, maxLen int) (got string,
 
 	hasDelimiter := false
 	size = min(endIndex, delimiterIndex)
-	if size > maxLen {
+	if size >= maxLen {
 		size = maxLen
 	} else if size < maxLen {
 		if delimiterIndex == size {

--- a/converters_test.go
+++ b/converters_test.go
@@ -59,6 +59,11 @@ func TestConverters__parseVariableStringField(t *testing.T) {
 	require.Equal(t, "123", got)
 	require.Equal(t, 3, size)
 	require.Nil(t, err)
+
+	got, size, err = c.parseVariableStringField("123*567", 3)
+	require.Equal(t, "123", got)
+	require.Equal(t, 3, size)
+	require.Nil(t, err)
 }
 
 func TestConverters_alphaVariableField(t *testing.T) {


### PR DESCRIPTION
This fix addresses a minor bug when the field lengths are equal to the maxLen. 

**Specifically**, when running a validation against the `{6000}` element of a wire, there was an error being generated when the Originator to Beneficiary Information had a field length of 35 characters. The FedWire Spec allows for up to **4 lines of 35 characters each**. This change will allow for the fields to be equal to the max allowed length of 35 and prevent the generation of the error message: `error reading file: line:n record:OriginatorToBeneficiary wire.TagWrongLenthErr contains invalid information in a segment`

![image](https://user-images.githubusercontent.com/2130829/189414689-e72c7045-84a6-4875-b331-f43d7a0132ef.png)
