### PR TITLE
fix: [issue#240] BusinessFunctionCode.TransactionTypeCode variable length formatting

### DIFF
--- a/businessFunctionCode.go
+++ b/businessFunctionCode.go
@@ -134,5 +134,9 @@ func (bfc *BusinessFunctionCode) TransactionTypeCodeField() string {
 
 // FormatTransactionTypeCode returns TransactionTypeCode formatted according to the FormatOptions
 func (bfc *BusinessFunctionCode) FormatTransactionTypeCode(options FormatOptions) string {
+	// for variable length and empty TransactionTypeCode, no formatting is needed
+	if options.VariableLengthFields && bfc.TransactionTypeCode == "" {
+		return ""
+	}
 	return bfc.formatAlphaField(bfc.TransactionTypeCode, 3, options)
 }

--- a/businessFunctionCode_test.go
+++ b/businessFunctionCode_test.go
@@ -114,7 +114,7 @@ func TestStringBusinessFunctionCodeVariableLength(t *testing.T) {
 
 // TestStringBusinessFunctionCodeOptions validates Format() formatted according to the FormatOptions
 func TestStringBusinessFunctionCodeOptions(t *testing.T) {
-	var line = "{3600}BTR*"
+	var line = "{3600}BTR"
 	r := NewReader(strings.NewReader(line))
 	r.line = line
 
@@ -123,7 +123,7 @@ func TestStringBusinessFunctionCodeOptions(t *testing.T) {
 
 	bfc := r.currentFEDWireMessage.BusinessFunctionCode
 	require.Equal(t, bfc.String(), "{3600}BTR   ")
-	require.Equal(t, bfc.Format(FormatOptions{VariableLengthFields: true}), "{3600}BTR*")
+	require.Equal(t, bfc.Format(FormatOptions{VariableLengthFields: true}), "{3600}BTR")
 	require.Equal(t, bfc.String(), bfc.Format(FormatOptions{VariableLengthFields: false}))
 
 }


### PR DESCRIPTION
#### Changes

- Added a check for variable length and empty TransactionTypeCode - no formatting is needed
- Updated tests

closes #240 