### PR TITLE
Validation of OriginatorFI and OriginatorToBeneficiary

### DIFF
--- a/fedWireMessage.go
+++ b/fedWireMessage.go
@@ -1065,8 +1065,8 @@ func (fwm *FEDWireMessage) validateOriginatorFI() error {
 	if fwm.OriginatorFI != nil {
 		switch fwm.BusinessFunctionCode.BusinessFunctionCode {
 		case CustomerTransferPlus:
-			if fwm.OriginatorOptionF == nil {
-				return fieldError("OriginatorOptionF", ErrFieldRequired)
+			if fwm.OriginatorOptionF == nil && fwm.Originator == nil {
+				return fieldError("Originator or OriginatorOptionF", ErrFieldRequired)
 			}
 		default:
 			if fwm.Originator == nil {
@@ -1107,8 +1107,8 @@ func (fwm *FEDWireMessage) validateOriginatorToBeneficiary() error {
 		}
 		switch fwm.BusinessFunctionCode.BusinessFunctionCode {
 		case CustomerTransferPlus:
-			if fwm.OriginatorOptionF == nil {
-				return fieldError("OriginatorOptionF", ErrFieldRequired)
+			if fwm.OriginatorOptionF == nil && fwm.Originator == nil {
+				return fieldError("Originator or OriginatorOptionF", ErrFieldRequired)
 			}
 		default:
 			if fwm.Originator == nil {

--- a/fedWiremessage_test.go
+++ b/fedWiremessage_test.go
@@ -168,12 +168,20 @@ func TestFEDWireMessage_validateOriginatorFI(t *testing.T) {
 	require.EqualError(t, err, fieldError("Originator", ErrFieldRequired).Error())
 
 	fwm.BusinessFunctionCode.BusinessFunctionCode = CustomerTransferPlus
-	fwm.Originator = mockOriginator()
-
-	// OriginatorOptionF required field check
 	err = fwm.validateOriginatorFI()
 
-	require.EqualError(t, err, fieldError("OriginatorOptionF", ErrFieldRequired).Error())
+	require.EqualError(t, err, fieldError("Originator or OriginatorOptionF", ErrFieldRequired).Error())
+
+	fwm.Originator = mockOriginator()
+	err = fwm.validateOriginatorFI()
+
+	require.NoError(t, err)
+
+	fwm.Originator = nil
+	fwm.OriginatorOptionF = mockOriginatorOptionF()
+	err = fwm.validateOriginatorFI()
+
+	require.NoError(t, err)
 }
 
 func TestFEDWireMessage_validateInstructingFI(t *testing.T) {
@@ -216,14 +224,28 @@ func TestNewFEDWireMessage_validateOriginatorToBeneficiary(t *testing.T) {
 	expected = fieldError("Originator", ErrFieldRequired).Error()
 	require.EqualError(t, err, expected)
 
-	fwm.Originator = mockOriginator()
 	fwm.BusinessFunctionCode.BusinessFunctionCode = CustomerTransferPlus
 
 	// OriginatorOptionF required Field check
 	err = fwm.validateOriginatorToBeneficiary()
 
-	expected = fieldError("OriginatorOptionF", ErrFieldRequired).Error()
+	expected = fieldError("Originator or OriginatorOptionF", ErrFieldRequired).Error()
 	require.EqualError(t, err, expected)
+
+	fwm.Originator = mockOriginator()
+
+	// OriginatorOptionF required Field check
+	err = fwm.validateOriginatorToBeneficiary()
+
+	require.NoError(t, err)
+
+	fwm.Originator = nil
+	fwm.OriginatorOptionF = mockOriginatorOptionF()
+
+	// OriginatorOptionF required Field check
+	err = fwm.validateOriginatorToBeneficiary()
+
+	require.NoError(t, err)
 
 	// check beneficiary still required
 	fwm.Beneficiary = nil


### PR DESCRIPTION
If tag {6000} is present and the business function code is not CTP, {4200} and {5000} are mandatory.
If tag {6000} is present and the business function code Is CTP, {4200} and ( either of {5000} or {5010} ) are mandatory.