### PR TITLE
Fix for ID code & Identifier validation.  Updated alphanumeric regex

### DIFF
--- a/beneficiary.go
+++ b/beneficiary.go
@@ -137,12 +137,16 @@ func (ben *Beneficiary) Validate() error {
 	if ben.tag != TagBeneficiary {
 		return fieldError("tag", ErrValidTagForType, ben.tag)
 	}
-	// Can be any Identification Code
-	if err := ben.isIdentificationCode(ben.Personal.IdentificationCode); err != nil {
-		return fieldError("IdentificationCode", err, ben.Personal.IdentificationCode)
-	}
-	if err := ben.isAlphanumeric(ben.Personal.Identifier); err != nil {
-		return fieldError("Identifier", err, ben.Personal.Identifier)
+	// Per FAIM 3.0.6, Beneficiary ID code is optional
+	if ben.Personal.IdentificationCode != "" {
+		// If it is present, confirm it is a valid code
+		if err := ben.isIdentificationCode(ben.Personal.IdentificationCode); err != nil {
+			return fieldError("IdentificationCode", err, ben.Personal.IdentificationCode)
+		}
+		// Identifier must also be present when ID code is present
+		if err := ben.isAlphanumeric(ben.Personal.Identifier); err != nil {
+			return fieldError("Identifier", err, ben.Personal.Identifier)
+		}
 	}
 	if err := ben.isAlphanumeric(ben.Personal.Name); err != nil {
 		return fieldError("Name", err, ben.Personal.Name)

--- a/beneficiary.go
+++ b/beneficiary.go
@@ -131,23 +131,28 @@ func (ben *Beneficiary) Format(options FormatOptions) string {
 // The first error encountered is returned and stops that parsing.
 // If ID Code is present, Identifier is mandatory and vice versa.
 func (ben *Beneficiary) Validate() error {
-	if err := ben.fieldInclusion(); err != nil {
-		return err
-	}
 	if ben.tag != TagBeneficiary {
 		return fieldError("tag", ErrValidTagForType, ben.tag)
 	}
-	// Per FAIM 3.0.6, Beneficiary ID code is optional
+
+	if err := ben.fieldInclusion(); err != nil {
+		return err
+	}
+
+	// Per FAIM 3.0.6, Beneficiary ID code is optional.
+	// fieldInclusion() above already checks for the mandatory combination of IDCode & Identifier
+	// Here we are checking for allowed values (in IDCode) and text characters (in Identifier)
 	if ben.Personal.IdentificationCode != "" {
 		// If it is present, confirm it is a valid code
 		if err := ben.isIdentificationCode(ben.Personal.IdentificationCode); err != nil {
 			return fieldError("IdentificationCode", err, ben.Personal.IdentificationCode)
 		}
-		// Identifier must also be present when ID code is present
+		// Identifier text must only contain allowed characters
 		if err := ben.isAlphanumeric(ben.Personal.Identifier); err != nil {
 			return fieldError("Identifier", err, ben.Personal.Identifier)
 		}
 	}
+
 	if err := ben.isAlphanumeric(ben.Personal.Name); err != nil {
 		return fieldError("Name", err, ben.Personal.Name)
 	}

--- a/beneficiary_test.go
+++ b/beneficiary_test.go
@@ -87,24 +87,28 @@ func TestBeneficiaryAddressLineThreeAlphaNumeric(t *testing.T) {
 	require.EqualError(t, err, fieldError("AddressLineThree", ErrNonAlphanumeric, ben.Personal.Address.AddressLineThree).Error())
 }
 
-// TestBeneficiaryIdentificationCodeRequired validates Beneficiary IdentificationCode is required
-func TestBeneficiaryIdentificationCodeRequired(t *testing.T) {
+// TestBeneficiaryIdentificationCodeWithNoIdentifier validates Beneficiary Identifier is required
+// when IdentificationCode is present
+func TestBeneficiaryIdentificationCodeWithNoIdentifier(t *testing.T) {
 	ben := mockBeneficiary()
-	ben.Personal.IdentificationCode = ""
-
-	err := ben.Validate()
-
-	require.EqualError(t, err, fieldError("IdentificationCode", ErrFieldRequired).Error())
-}
-
-// TestBeneficiaryIdentifierRequired validates Beneficiary Identifier is required
-func TestBeneficiaryIdentifierRequired(t *testing.T) {
-	ben := mockBeneficiary()
+	ben.Personal.IdentificationCode = "D"
 	ben.Personal.Identifier = ""
 
 	err := ben.Validate()
 
 	require.EqualError(t, err, fieldError("Identifier", ErrFieldRequired).Error())
+}
+
+// TestBeneficiaryIdentifierWithNoIdentificationCode validates Beneficiary IdentificationCode
+// is required when Identifier is present
+func TestBeneficiaryIdentifierWithNoIdentificationCode(t *testing.T) {
+	ben := mockBeneficiary()
+	ben.Personal.IdentificationCode = ""
+	ben.Personal.Identifier = "1234567890ABC"
+
+	err := ben.Validate()
+
+	require.EqualError(t, err, fieldError("IdentificationCode", ErrFieldRequired).Error())
 }
 
 // TestParseBeneficiaryWrongLength parses a wrong Beneficiary record length

--- a/originator.go
+++ b/originator.go
@@ -136,12 +136,17 @@ func (o *Originator) Validate() error {
 	if o.tag != TagOriginator {
 		return fieldError("tag", ErrValidTagForType, o.tag)
 	}
-	// Can be any Identification Code
-	if err := o.isIdentificationCode(o.Personal.IdentificationCode); err != nil {
-		return fieldError("IdentificationCode", err, o.Personal.IdentificationCode)
-	}
-	if err := o.isAlphanumeric(o.Personal.Identifier); err != nil {
-		return fieldError("Identifier", err, o.Personal.Identifier)
+
+	// Per FAIM 3.0.6, Originator ID code is optional
+	if o.Personal.IdentificationCode != "" {
+		// If it is present, confirm it is a valid code
+		if err := o.isIdentificationCode(o.Personal.IdentificationCode); err != nil {
+			return fieldError("IdentificationCode", err, o.Personal.IdentificationCode)
+		}
+		// Identifier must also be present when ID code is present
+		if err := o.isAlphanumeric(o.Personal.Identifier); err != nil {
+			return fieldError("Identifier", err, o.Personal.Identifier)
+		}
 	}
 	if err := o.isAlphanumeric(o.Personal.Name); err != nil {
 		return fieldError("Name", err, o.Personal.Name)

--- a/originator.go
+++ b/originator.go
@@ -130,24 +130,28 @@ func (o *Originator) Format(options FormatOptions) string {
 // Validate performs WIRE format rule checks on Originator and returns an error if not Validated
 // The first error encountered is returned and stops that parsing.
 func (o *Originator) Validate() error {
-	if err := o.fieldInclusion(); err != nil {
-		return err
-	}
 	if o.tag != TagOriginator {
 		return fieldError("tag", ErrValidTagForType, o.tag)
 	}
 
+	if err := o.fieldInclusion(); err != nil {
+		return err
+	}
+
 	// Per FAIM 3.0.6, Originator ID code is optional
+	// fieldInclusion() above already checks for the mandatory combination of IDCode & Identifier
+	// Here we are checking for allowed values (in IDCode) and text characters (in Identifier)
 	if o.Personal.IdentificationCode != "" {
 		// If it is present, confirm it is a valid code
 		if err := o.isIdentificationCode(o.Personal.IdentificationCode); err != nil {
 			return fieldError("IdentificationCode", err, o.Personal.IdentificationCode)
 		}
-		// Identifier must also be present when ID code is present
+		// Identifier text must only contain allowed characters
 		if err := o.isAlphanumeric(o.Personal.Identifier); err != nil {
 			return fieldError("Identifier", err, o.Personal.Identifier)
 		}
 	}
+
 	if err := o.isAlphanumeric(o.Personal.Name); err != nil {
 		return fieldError("Name", err, o.Personal.Name)
 	}

--- a/originator_test.go
+++ b/originator_test.go
@@ -90,24 +90,28 @@ func TestOriginatorAddressLineThreeAlphaNumeric(t *testing.T) {
 	require.EqualError(t, err, fieldError("AddressLineThree", ErrNonAlphanumeric, o.Personal.Address.AddressLineThree).Error())
 }
 
-// TestOriginatorIdentificationCodeRequired validates Originator IdentificationCode is required
-func TestOriginatorIdentificationCodeRequired(t *testing.T) {
+// TestOriginatorIdentificationCodeWithNoIdentifier validates Originator Identifier is required
+// when IdentificationCode is present
+func TestOriginatorIdentificationCodeWithNoIdentifier(t *testing.T) {
 	o := mockOriginator()
-	o.Personal.IdentificationCode = ""
-
-	err := o.Validate()
-
-	require.EqualError(t, err, fieldError("IdentificationCode", ErrFieldRequired).Error())
-}
-
-// TestOriginatorIdentifierRequired validates Originator Identifier is required
-func TestOriginatorIdentifierRequired(t *testing.T) {
-	o := mockOriginator()
+	o.Personal.IdentificationCode = "D"
 	o.Personal.Identifier = ""
 
 	err := o.Validate()
 
 	require.EqualError(t, err, fieldError("Identifier", ErrFieldRequired).Error())
+}
+
+// TestOriginatorIdentifierWithNoIdentificationCode validates Originator IdentificationCode
+// is required when Identifier is present
+func TestOriginatorIdentifierWithNoIdentificationCode(t *testing.T) {
+	o := mockOriginator()
+	o.Personal.IdentificationCode = ""
+	o.Personal.Identifier = "1234567890ABC"
+
+	err := o.Validate()
+
+	require.EqualError(t, err, fieldError("IdentificationCode", ErrFieldRequired).Error())
 }
 
 // TestParseOriginatorWrongLength parses a wrong Originator record length

--- a/validators.go
+++ b/validators.go
@@ -14,9 +14,10 @@ import (
 
 var (
 	// upperAlphanumericRegex = regexp.MustCompile(`[^ A-Z0-9!"#$%&'()*+,-.\\/:;<>=?@\[\]^_{}|~]+`)
-	// alphanumericRegex = regexp.MustCompile(`[^ \w!"#$%&'()*+,-.\\/:;<>=?@\[\]^_{}|~]+`)
 
-	// Alpha-Numeric including spaces and special characters as defined by FAIM 3.0.6
+	// Alpha-Numeric including spaces and special characters as defined by FAIM 3.0.6:
+	//   . ? ! , ; : _ @ & / \ ' " ` ~ ( ) < > $ # % + - =
+	// NOTE: This applies to all Fedwire tags except {8200} Unstructured Addenda Info
 	alphanumericRegex = regexp.MustCompile(`[^ \w.?!,;:_@&/\\'"\x60~()<>$#%+-=]+`)
 
 	numericRegex = regexp.MustCompile(`[^0-9]`)
@@ -29,7 +30,6 @@ type validator struct{}
 // isAlphanumeric checks if a string only contains ASCII alphanumeric characters
 func (v *validator) isAlphanumeric(s string) error {
 	if alphanumericRegex.MatchString(s) {
-		// ^[ A-Za-z0-9_@./#&+-]*$/
 		return ErrNonAlphanumeric
 	}
 	return nil

--- a/validators.go
+++ b/validators.go
@@ -14,9 +14,13 @@ import (
 
 var (
 	// upperAlphanumericRegex = regexp.MustCompile(`[^ A-Z0-9!"#$%&'()*+,-.\\/:;<>=?@\[\]^_{}|~]+`)
-	alphanumericRegex = regexp.MustCompile(`[^ \w!"#$%&'()*+,-.\\/:;<>=?@\[\]^_{}|~]+`)
-	numericRegex      = regexp.MustCompile(`[^0-9]`)
-	amountRegex       = regexp.MustCompile("[^0-9,.]")
+	// alphanumericRegex = regexp.MustCompile(`[^ \w!"#$%&'()*+,-.\\/:;<>=?@\[\]^_{}|~]+`)
+
+	// Alpha-Numeric including spaces and special characters as defined by FAIM 3.0.6
+	alphanumericRegex = regexp.MustCompile(`[^ \w.?!,;:_@&/\\'"\x60~()<>$#%+-=]+`)
+
+	numericRegex = regexp.MustCompile(`[^0-9]`)
+	amountRegex  = regexp.MustCompile("[^0-9,.]")
 )
 
 // validator is common validation and formatting of golang types to WIRE type strings

--- a/validators_test.go
+++ b/validators_test.go
@@ -19,3 +19,11 @@ func TestValidators__validateOptionFName(t *testing.T) {
 	require.Error(t, v.validateOptionFName(""))
 	require.Error(t, v.validateOptionFName(" /"))
 }
+
+func TestValidators__isAlphanumeric(t *testing.T) {
+	v := &validator{}
+
+	require.NoError(t, v.isAlphanumeric("Telepathic Bank (U.K.) / Acct #12345-ABC"))
+	require.Error(t, v.isAlphanumeric("{1100}"))
+	require.Error(t, v.isAlphanumeric("*"))
+}


### PR DESCRIPTION
<!-- Please fill out the following questions, thanks! -->

This pull request includes two items:
* Fixed `IdentificationCode` and `Identifier` validation logic for the Originator {5000} and Beneficiary {4200} tags
* Update to regex to include the correct special characters

**What Wire specification are you referencing?**
3.0.6+

**What issue(s) does this pull request reference?**
N/A