### PR TITLE
api: expose file.isIncoming as a query param

### DIFF
--- a/client/api/openapi.yaml
+++ b/client/api/openapi.yaml
@@ -78,6 +78,16 @@ paths:
         schema:
           type: string
         style: simple
+      - description: Optional flag to indicate if the file is incoming or outgoing.
+          SenderSupplied (tag 1500) is not required for incoming files.
+        explode: true
+        in: query
+        name: isIncoming
+        required: false
+        schema:
+          example: true
+          type: boolean
+        style: form
       requestBody:
         content:
           application/json:

--- a/client/api_wire_files.go
+++ b/client/api_wire_files.go
@@ -110,6 +110,7 @@ func (a *WireFilesApiService) AddFEDWireMessageToFile(ctx _context.Context, file
 // CreateWireFileOpts Optional parameters for the method 'CreateWireFile'
 type CreateWireFileOpts struct {
 	XRequestID optional.String
+	IsIncoming optional.Bool
 }
 
 /*
@@ -119,6 +120,7 @@ Create a new File object from either the plaintext or JSON representation.
   - @param wireFile Content of the Wire file (in json or raw text)
   - @param optional nil or *CreateWireFileOpts - Optional Parameters:
   - @param "XRequestID" (optional.String) -  Optional Request ID allows application developer to trace requests through the system's logs
+  - @param "IsIncoming" (optional.Bool) -  Optional flag to indicate if the file is incoming or outgoing. SenderSupplied (tag 1500) is not required for incoming files.
 
 @return WireFile
 */
@@ -139,6 +141,9 @@ func (a *WireFilesApiService) CreateWireFile(ctx _context.Context, wireFile Wire
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 
+	if localVarOptionals != nil && localVarOptionals.IsIncoming.IsSet() {
+		localVarQueryParams.Add("isIncoming", parameterToString(localVarOptionals.IsIncoming.Value(), ""))
+	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json", "text/plain"}
 

--- a/client/client.go
+++ b/client/client.go
@@ -392,9 +392,7 @@ func setBody(body interface{}, contentType string) (bodyBuf *bytes.Buffer, err e
 	} else if jsonCheck.MatchString(contentType) {
 		err = json.NewEncoder(bodyBuf).Encode(body)
 	} else if xmlCheck.MatchString(contentType) {
-		encoder := xml.NewEncoder(bodyBuf)
-		defer encoder.Close()
-		err = encoder.Encode(body)
+		err = xml.NewEncoder(bodyBuf).Encode(body)
 	}
 
 	if err != nil {

--- a/client/docs/WireFilesApi.md
+++ b/client/docs/WireFilesApi.md
@@ -88,6 +88,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
  **xRequestID** | **optional.String**| Optional Request ID allows application developer to trace requests through the system&#39;s logs | 
+ **isIncoming** | **optional.Bool**| Optional flag to indicate if the file is incoming or outgoing. SenderSupplied (tag 1500) is not required for incoming files. | 
 
 ### Return type
 

--- a/cmd/server/files.go
+++ b/cmd/server/files.go
@@ -96,7 +96,12 @@ func createFile(logger log.Logger, repo WireFileRepository) http.HandlerFunc {
 
 		w = wrapResponseWriter(logger, w, r)
 
-		req := wire.NewFile()
+		var opts []wire.FilePropertyFunc
+		if strings.EqualFold("true", r.URL.Query().Get("isIncoming")) {
+			opts = append(opts, wire.IncomingFile())
+		}
+
+		req := wire.NewFile(opts...)
 		req.ID = base.ID()
 
 		if strings.Contains(r.Header.Get("Content-Type"), "application/json") {
@@ -111,7 +116,7 @@ func createFile(logger log.Logger, repo WireFileRepository) http.HandlerFunc {
 				return
 			}
 		} else {
-			file, err := wire.NewReader(r.Body).Read()
+			file, err := wire.NewReader(r.Body, opts...).Read()
 			if err != nil {
 				err = logger.LogErrorf("error reading file: %v", err).Err()
 				moovhttp.Problem(w, err)

--- a/file.go
+++ b/file.go
@@ -15,7 +15,7 @@ type File struct {
 	ID             string         `json:"id"`
 	FEDWireMessage FEDWireMessage `json:"fedWireMessage"`
 
-	isIncoming bool `json:"-"`
+	isIncoming bool
 }
 
 // NewFile constructs a file template
@@ -75,7 +75,7 @@ func (f *File) Validate() error {
 // be rejected by other Financial Institutions or ACH tools.
 func FileFromJSON(bs []byte) (*File, error) {
 	if len(bs) == 0 {
-		//return nil, errors.New("no JSON data provided")
+		// return nil, errors.New("no JSON data provided")
 		return nil, nil
 	}
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -71,6 +71,13 @@ paths:
           example: rs4f9915
           schema:
             type: string
+        - name: isIncoming
+          in: query
+          description: Optional flag to indicate if the file is incoming or outgoing. SenderSupplied (tag 1500) is not required for incoming files.
+          required: false
+          schema:
+            type: boolean
+            example: true
       requestBody:
         description: Content of the Wire file (in json or raw text)
         required: true

--- a/reader.go
+++ b/reader.go
@@ -56,10 +56,10 @@ func (r *Reader) parseError(err error) error {
 }
 
 // NewReader returns a new ACH Reader that reads from r.
-func NewReader(r io.Reader) *Reader {
+func NewReader(r io.Reader, opts ...FilePropertyFunc) *Reader {
 	reader := &Reader{
 		scanner: bufio.NewScanner(r),
-		File:    *NewFile(IncomingFile()),
+		File:    *NewFile(opts...),
 	}
 
 	reader.scanner.Split(scanLinesWithSegmentFormat)

--- a/writer.go
+++ b/writer.go
@@ -84,7 +84,7 @@ func (w *Writer) writeFEDWireMessage(file *File) error {
 
 	fwm := file.FEDWireMessage
 
-	if err := w.writeMandatory(fwm); err != nil {
+	if err := w.writeMandatory(fwm, file.isIncoming); err != nil {
 		return err
 	}
 
@@ -160,14 +160,16 @@ func (w *Writer) writeFedAppended(fwm FEDWireMessage) error {
 	return nil
 }
 
-func (w *Writer) writeMandatory(fwm FEDWireMessage) error {
+func (w *Writer) writeMandatory(fwm FEDWireMessage, isIncoming bool) error {
 
 	if fwm.SenderSupplied != nil {
 		if _, err := w.w.WriteString(fwm.SenderSupplied.Format(w.FormatOptions) + w.NewlineCharacter); err != nil {
 			return err
 		}
 	} else {
-		return fieldError("SenderSupplied", ErrFieldRequired)
+		if !isIncoming {
+			return fieldError("SenderSupplied", ErrFieldRequired)
+		}
 	}
 
 	if fwm.TypeSubType != nil {


### PR DESCRIPTION
<!-- Please fill out the following questions, thanks! -->

The `file.isIncoming` flag wasn't being honored consistently between files created via JSON or file upload. Additionally, writing an incoming file without `SenderSupplied` would fail because the writer wasn't checking `isIncoming`.

This change makes it possible to explicitly specify `isIncoming` on file creation via query param, and honors the flag in all subsequent requests (get file, get file contents, etc.).