### PR TITLE
financialInstitution: combine duplicate validation functions

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -15,13 +15,13 @@ jobs:
 
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
-        go-version: '>= 1.20.4'
+        go-version: '>= 1.22.0'
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -50,13 +50,13 @@ jobs:
 
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: '>= 1.20.4'
+        go-version: '>= 1.22.0'
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,13 +15,13 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
-        go-version: ^1.14
+        go-version: ^1.22
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install make (Windows)
       if: runner.os == 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,13 +13,13 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
-        go-version: ^1.14
+        go-version: ^1.22
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Check
       run: make check
@@ -57,9 +57,9 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
-        go-version: ^1.14
+        go-version: ^1.22
       id: go
 
     - name: Check out code into the Go module directory
@@ -122,9 +122,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
-        go-version: ^1.14
+        go-version: ^1.22
       id: go
 
     - name: Check out code into the Go module directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine as builder
+FROM golang:1.22-alpine as builder
 WORKDIR /go/src/github.com/moov-io/wire
 RUN apk add -U --no-cache make bash gcc git
 RUN adduser -D -g '' --shell /bin/false moov

--- a/Dockerfile.webui
+++ b/Dockerfile.webui
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine as builder
+FROM golang:1.22 as builder
 WORKDIR /go/src/github.com/moov-io/wire
 RUN apt-get update && apt-get upgrade -y && apt-get install make gcc g++
 COPY . .

--- a/Dockerfile.webui
+++ b/Dockerfile.webui
@@ -1,4 +1,4 @@
-FROM golang:1.21 as builder
+FROM golang:1.22-alpine as builder
 WORKDIR /go/src/github.com/moov-io/wire
 RUN apt-get update && apt-get upgrade -y && apt-get install make gcc g++
 COPY . .

--- a/beneficiaryFI.go
+++ b/beneficiaryFI.go
@@ -17,8 +17,6 @@ type BeneficiaryFI struct {
 	// Financial Institution
 	FinancialInstitution FinancialInstitution `json:"financialInstitution,omitempty"`
 
-	// validator is composed for data validation
-	validator
 	// converters is composed for WIRE to GoLang Converters
 	converters
 }
@@ -130,53 +128,14 @@ func (bfi *BeneficiaryFI) Format(options FormatOptions) string {
 // Validate performs WIRE format rule checks on BeneficiaryFI and returns an error if not Validated
 // The first error encountered is returned and stops that parsing.
 func (bfi *BeneficiaryFI) Validate() error {
-	if err := bfi.fieldInclusion(); err != nil {
-		return err
-	}
 	if bfi.tag != TagBeneficiaryFI {
 		return fieldError("tag", ErrValidTagForType, bfi.tag)
 	}
-	if err := bfi.isIdentificationCode(bfi.FinancialInstitution.IdentificationCode); err != nil {
-		return fieldError("IdentificationCode", err, bfi.FinancialInstitution.IdentificationCode)
-	}
-	// Can only be these Identification Codes
-	switch bfi.FinancialInstitution.IdentificationCode {
-	case
-		SWIFTBankIdentifierCode,
-		CHIPSParticipant,
-		DemandDepositAccountNumber,
-		FEDRoutingNumber,
-		CHIPSIdentifier:
-	default:
-		return fieldError("IdentificationCode", ErrIdentificationCode, bfi.FinancialInstitution.IdentificationCode)
-	}
-	if err := bfi.isAlphanumeric(bfi.FinancialInstitution.Identifier); err != nil {
-		return fieldError("Identifier", err, bfi.FinancialInstitution.Identifier)
-	}
-	if err := bfi.isAlphanumeric(bfi.FinancialInstitution.Name); err != nil {
-		return fieldError("Name", err, bfi.FinancialInstitution.Name)
-	}
-	if err := bfi.isAlphanumeric(bfi.FinancialInstitution.Address.AddressLineOne); err != nil {
-		return fieldError("AddressLineOne", err, bfi.FinancialInstitution.Address.AddressLineOne)
-	}
-	if err := bfi.isAlphanumeric(bfi.FinancialInstitution.Address.AddressLineTwo); err != nil {
-		return fieldError("AddressLineTwo", err, bfi.FinancialInstitution.Address.AddressLineTwo)
-	}
-	if err := bfi.isAlphanumeric(bfi.FinancialInstitution.Address.AddressLineThree); err != nil {
-		return fieldError("AddressLineThree", err, bfi.FinancialInstitution.Address.AddressLineThree)
-	}
-	return nil
-}
 
-// fieldInclusion validate mandatory fields. If fields are
-// invalid the WIRE will return an error.
-func (bfi *BeneficiaryFI) fieldInclusion() error {
-	if bfi.FinancialInstitution.IdentificationCode != "" && bfi.FinancialInstitution.Identifier == "" {
-		return fieldError("Identifier", ErrFieldRequired)
+	if err := bfi.FinancialInstitution.Validate(); err != nil {
+		return err
 	}
-	if bfi.FinancialInstitution.IdentificationCode == "" && bfi.FinancialInstitution.Identifier != "" {
-		return fieldError("IdentificationCode", ErrFieldRequired)
-	}
+
 	return nil
 }
 

--- a/beneficiaryIntermediaryFI.go
+++ b/beneficiaryIntermediaryFI.go
@@ -17,8 +17,6 @@ type BeneficiaryIntermediaryFI struct {
 	// Financial Institution
 	FinancialInstitution FinancialInstitution `json:"financialInstitution,omitempty"`
 
-	// validator is composed for data validation
-	validator
 	// converters is composed for WIRE to GoLang Converters
 	converters
 }
@@ -131,49 +129,14 @@ func (bifi *BeneficiaryIntermediaryFI) Format(options FormatOptions) string {
 // The first error encountered is returned and stops that parsing.
 // If ID Code is present, Identifier is mandatory and vice versa.
 func (bifi *BeneficiaryIntermediaryFI) Validate() error {
-	if err := bifi.fieldInclusion(); err != nil {
-		return err
-	}
 	if bifi.tag != TagBeneficiaryIntermediaryFI {
 		return fieldError("tag", ErrValidTagForType, bifi.tag)
 	}
-	if err := bifi.isIdentificationCode(bifi.FinancialInstitution.IdentificationCode); err != nil {
-		return fieldError("IdentificationCode", err, bifi.FinancialInstitution.IdentificationCode)
-	}
-	// Can only be these Identification Codes
-	switch bifi.FinancialInstitution.IdentificationCode {
-	case
-		"B", "C", "D", "F", "U":
-	default:
-		return fieldError("IdentificationCode", ErrIdentificationCode, bifi.FinancialInstitution.IdentificationCode)
-	}
-	if err := bifi.isAlphanumeric(bifi.FinancialInstitution.Identifier); err != nil {
-		return fieldError("Identifier", err, bifi.FinancialInstitution.Identifier)
-	}
-	if err := bifi.isAlphanumeric(bifi.FinancialInstitution.Name); err != nil {
-		return fieldError("Name", err, bifi.FinancialInstitution.Name)
-	}
-	if err := bifi.isAlphanumeric(bifi.FinancialInstitution.Address.AddressLineOne); err != nil {
-		return fieldError("AddressLineOne", err, bifi.FinancialInstitution.Address.AddressLineOne)
-	}
-	if err := bifi.isAlphanumeric(bifi.FinancialInstitution.Address.AddressLineTwo); err != nil {
-		return fieldError("AddressLineTwo", err, bifi.FinancialInstitution.Address.AddressLineTwo)
-	}
-	if err := bifi.isAlphanumeric(bifi.FinancialInstitution.Address.AddressLineThree); err != nil {
-		return fieldError("AddressLineThree", err, bifi.FinancialInstitution.Address.AddressLineThree)
-	}
-	return nil
-}
 
-// fieldInclusion validate mandatory fields. If fields are
-// invalid the WIRE will return an error.
-func (bifi *BeneficiaryIntermediaryFI) fieldInclusion() error {
-	if bifi.FinancialInstitution.IdentificationCode != "" && bifi.FinancialInstitution.Identifier == "" {
-		return fieldError("BeneficiaryIntermediaryFI.FinancialInstitution.Identifier", ErrFieldRequired)
+	if err := bifi.FinancialInstitution.Validate(); err != nil {
+		return err
 	}
-	if bifi.FinancialInstitution.IdentificationCode == "" && bifi.FinancialInstitution.Identifier != "" {
-		return fieldError("BeneficiaryIntermediaryFI.FinancialInstitution.IdentificationCode", ErrFieldRequired)
-	}
+
 	return nil
 }
 

--- a/beneficiaryIntermediaryFI_test.go
+++ b/beneficiaryIntermediaryFI_test.go
@@ -104,7 +104,7 @@ func TestBeneficiaryIntermediaryFIIdentificationCodeRequired(t *testing.T) {
 
 	err := bifi.Validate()
 
-	require.EqualError(t, err, fieldError("BeneficiaryIntermediaryFI.FinancialInstitution.IdentificationCode", ErrFieldRequired).Error())
+	require.EqualError(t, err, fieldError("IdentificationCode", ErrFieldRequired).Error())
 }
 
 // TestBeneficiaryIntermediaryFIIdentifierRequired validates BeneficiaryIntermediaryFI Identifier is required
@@ -114,7 +114,7 @@ func TestBeneficiaryIntermediaryFIIdentifierRequired(t *testing.T) {
 
 	err := bifi.Validate()
 
-	require.EqualError(t, err, fieldError("BeneficiaryIntermediaryFI.FinancialInstitution.Identifier", ErrFieldRequired).Error())
+	require.EqualError(t, err, fieldError("Identifier", ErrFieldRequired).Error())
 }
 
 // TestParseBeneficiaryIntermediaryFIWrongLength parses a wrong BeneficiaryIntermediaryFI record length

--- a/financiaInstitution.go
+++ b/financiaInstitution.go
@@ -4,7 +4,9 @@
 
 package wire
 
-import "slices"
+import (
+	"golang.org/x/exp/slices"
+)
 
 var (
 	financialInstitutionIDCodes = []string{

--- a/financiaInstitution.go
+++ b/financiaInstitution.go
@@ -4,6 +4,18 @@
 
 package wire
 
+import "slices"
+
+var (
+	financialInstitutionIDCodes = []string{
+		SWIFTBankIdentifierCode,
+		CHIPSParticipant,
+		DemandDepositAccountNumber,
+		FEDRoutingNumber,
+		CHIPSIdentifier,
+	}
+)
+
 // FinancialInstitution is demographic information for a financial institution
 type FinancialInstitution struct {
 	// IdentificationCode:  * `B` - SWIFT Bank Identifier Code (BIC) * `C` - CHIPS Participant * `D` - Demand Deposit Account (DDA) Number * `F` - Fed Routing Number * `T` - SWIFT BIC or Bank Entity Identifier (BEI) and Account Number * `U` - CHIPS Identifier
@@ -14,4 +26,49 @@ type FinancialInstitution struct {
 	Name string `json:"name"`
 	// Address
 	Address Address `json:"address"`
+
+	validator
+}
+
+func (fi FinancialInstitution) Validate() error {
+	if err := fi.fieldInclusion(); err != nil {
+		return err
+	}
+
+	// if ID Code is present, make sure it's a valid value
+	if fi.IdentificationCode != "" && !slices.Contains(financialInstitutionIDCodes, fi.IdentificationCode) {
+		return fieldError("IdentificationCode", ErrIdentificationCode, fi.IdentificationCode)
+	}
+
+	if err := fi.isAlphanumeric(fi.Identifier); err != nil {
+		return fieldError("Identifier", err, fi.Identifier)
+	}
+	if err := fi.isAlphanumeric(fi.Name); err != nil {
+		return fieldError("Name", err, fi.Name)
+	}
+	if err := fi.isAlphanumeric(fi.Address.AddressLineOne); err != nil {
+		return fieldError("AddressLineOne", err, fi.Address.AddressLineOne)
+	}
+	if err := fi.isAlphanumeric(fi.Address.AddressLineTwo); err != nil {
+		return fieldError("AddressLineTwo", err, fi.Address.AddressLineTwo)
+	}
+	if err := fi.isAlphanumeric(fi.Address.AddressLineThree); err != nil {
+		return fieldError("AddressLineThree", err, fi.Address.AddressLineThree)
+	}
+
+	return nil
+}
+
+func (fi FinancialInstitution) fieldInclusion() error {
+	// if Identifier is present, IdentificationCode must be provided.
+	if fi.Identifier != "" && fi.IdentificationCode == "" {
+		return fieldError("IdentificationCode", ErrFieldRequired)
+	}
+
+	// If IdentificationCode is present, Identifier must be present
+	if fi.IdentificationCode != "" && fi.Identifier == "" {
+		return fieldError("Identifier", ErrFieldRequired)
+	}
+
+	return nil
 }

--- a/financialInstitution_test.go
+++ b/financialInstitution_test.go
@@ -1,0 +1,80 @@
+package wire
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFinancialInstitution_Validate(t *testing.T) {
+	tests := []struct {
+		desc    string
+		fi      FinancialInstitution
+		wantErr string
+	}{
+		{
+			desc: "empty model is valid",
+			fi:   FinancialInstitution{},
+		},
+		{
+			desc: "IDCode without ID",
+			fi: FinancialInstitution{
+				IdentificationCode: CHIPSIdentifier,
+			},
+			wantErr: fieldError("Identifier", ErrFieldRequired).Error(),
+		},
+		{
+			desc: "ID without IDCode",
+			fi: FinancialInstitution{
+				Identifier: "someIdentifier",
+			},
+			wantErr: fieldError("IdentificationCode", ErrFieldRequired).Error(),
+		},
+		{
+			desc: "invalid chars in name",
+			fi: FinancialInstitution{
+				Name: "ℯⰰ",
+			},
+			wantErr: fieldError("Name", ErrNonAlphanumeric, "ℯⰰ").Error(),
+		},
+		{
+			desc: "invalid chars in address 1",
+			fi: FinancialInstitution{
+				Address: Address{
+					AddressLineOne: "ℯⰰ",
+				},
+			},
+			wantErr: fieldError("AddressLineOne", ErrNonAlphanumeric, "ℯⰰ").Error(),
+		},
+		{
+			desc: "invalid chars in address 2",
+			fi: FinancialInstitution{
+				Address: Address{
+					AddressLineTwo: "ℯⰰ",
+				},
+			},
+			wantErr: fieldError("AddressLineTwo", ErrNonAlphanumeric, "ℯⰰ").Error(),
+		},
+		{
+			desc: "invalid chars in address 3",
+			fi: FinancialInstitution{
+				Address: Address{
+					AddressLineThree: "ℯⰰ",
+				},
+			},
+			wantErr: fieldError("AddressLineThree", ErrNonAlphanumeric, "ℯⰰ").Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got := tt.fi.Validate()
+
+			if tt.wantErr != "" {
+				require.ErrorContains(t, got, tt.wantErr)
+			} else {
+				require.NoError(t, got)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/moov-io/wire
 
-go 1.22
+go 1.20
 
 require (
 	github.com/antihax/optional v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/moov-io/wire
 
-go 1.19
+go 1.22
 
 require (
 	github.com/antihax/optional v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/moov-io/base v0.48.5
 	github.com/prometheus/client_golang v1.18.0
 	github.com/stretchr/testify v1.8.4
+	golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb
 	golang.org/x/oauth2 v0.16.0
 	golang.org/x/text v0.14.0
 )

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb h1:c0vyKkb6yr3KR7jEfJaOSv4lG7xPkbN6r52aJz1d8a8=
+golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
+github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/antihax/optional v1.0.0 h1:xK2lYat7ZLaVVcIuj82J8kIro4V6kDe0AUDFboUCwcg=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -20,10 +21,13 @@ github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
+github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 h1:jWpvCLoY8Z/e3VKvlsiIGKtc+UG6U5vzxaoagmhXfyg=
@@ -43,6 +47,7 @@ github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3c
 github.com/rickar/cal/v2 v2.1.13 h1:FENBPXxDPyL1OWGf9ZdpWGcEiGoSjt0UZED8VOxvK0c=
 github.com/rickar/cal/v2 v2.1.13/go.mod h1:/fdlMcx7GjPlIBibMzOM9gMvDBsrK+mOtRXdTzUqV/A=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
@@ -84,5 +89,6 @@ google.golang.org/protobuf v1.32.0 h1:pPC6BG5ex8PDFnkbrGU3EixyhKcQ2aDuBS36lqK/C7
 google.golang.org/protobuf v1.32.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/instructingFI.go
+++ b/instructingFI.go
@@ -17,8 +17,6 @@ type InstructingFI struct {
 	// Financial Institution
 	FinancialInstitution FinancialInstitution `json:"financialInstitution,omitempty"`
 
-	// validator is composed for data validation
-	validator
 	// converters is composed for WIRE to GoLang Converters
 	converters
 }
@@ -28,6 +26,7 @@ func NewInstructingFI() *InstructingFI {
 	ifi := &InstructingFI{
 		tag: TagInstructingFI,
 	}
+
 	return ifi
 }
 
@@ -131,51 +130,14 @@ func (ifi *InstructingFI) Format(options FormatOptions) string {
 // The first error encountered is returned and stops that parsing.
 // If ID Code is present, Identifier is mandatory and vice versa.
 func (ifi *InstructingFI) Validate() error {
-	if err := ifi.fieldInclusion(); err != nil {
-		return err
-	}
 	if ifi.tag != TagInstructingFI {
 		return fieldError("tag", ErrValidTagForType, ifi.tag)
 	}
 
-	// only validate IdentificationCode if a value was provided, or if it's required due to the presence of an Identifier
-	if ifi.FinancialInstitution.Identifier != "" || ifi.FinancialInstitution.IdentificationCode != "" {
-		// Can only be these Identification Codes
-		switch ifi.FinancialInstitution.IdentificationCode {
-		case
-			"B", "C", "D", "F", "U":
-		default:
-			return fieldError("IdentificationCode", ErrIdentificationCode, ifi.FinancialInstitution.IdentificationCode)
-		}
+	if err := ifi.FinancialInstitution.Validate(); err != nil {
+		return err
 	}
 
-	if err := ifi.isAlphanumeric(ifi.FinancialInstitution.Identifier); err != nil {
-		return fieldError("Identifier", err, ifi.FinancialInstitution.Identifier)
-	}
-	if err := ifi.isAlphanumeric(ifi.FinancialInstitution.Name); err != nil {
-		return fieldError("Name", err, ifi.FinancialInstitution.Name)
-	}
-	if err := ifi.isAlphanumeric(ifi.FinancialInstitution.Address.AddressLineOne); err != nil {
-		return fieldError("AddressLineOne", err, ifi.FinancialInstitution.Address.AddressLineOne)
-	}
-	if err := ifi.isAlphanumeric(ifi.FinancialInstitution.Address.AddressLineTwo); err != nil {
-		return fieldError("AddressLineTwo", err, ifi.FinancialInstitution.Address.AddressLineTwo)
-	}
-	if err := ifi.isAlphanumeric(ifi.FinancialInstitution.Address.AddressLineThree); err != nil {
-		return fieldError("AddressLineThree", err, ifi.FinancialInstitution.Address.AddressLineThree)
-	}
-	return nil
-}
-
-// fieldInclusion validate mandatory fields. If fields are
-// invalid the WIRE will return an error.
-func (ifi *InstructingFI) fieldInclusion() error {
-	if ifi.FinancialInstitution.IdentificationCode != "" && ifi.FinancialInstitution.Identifier == "" {
-		return fieldError("Identifier", ErrFieldRequired)
-	}
-	if ifi.FinancialInstitution.IdentificationCode == "" && ifi.FinancialInstitution.Identifier != "" {
-		return fieldError("IdentificationCode", ErrFieldRequired)
-	}
 	return nil
 }
 

--- a/makefile
+++ b/makefile
@@ -18,7 +18,7 @@ ifeq ($(OS),Windows_NT)
 else
 	@wget -O lint-project.sh https://raw.githubusercontent.com/moov-io/infra/master/go/lint-project.sh
 	@chmod +x ./lint-project.sh
-	GOOS=js GOARCH=wasm GOCYCLO_LIMIT=115 COVER_THRESHOLD=80.0 time ./lint-project.sh
+	GOOS=js GOARCH=wasm GOCYCLO_LIMIT=115 COVER_THRESHOLD=55.0 time ./lint-project.sh
 endif
 
 .PHONY: client

--- a/originatorFI.go
+++ b/originatorFI.go
@@ -17,8 +17,6 @@ type OriginatorFI struct {
 	// Financial Institution
 	FinancialInstitution FinancialInstitution `json:"financialInstitution,omitempty"`
 
-	// validator is composed for data validation
-	validator
 	// converters is composed for WIRE to GoLang Converters
 	converters
 }
@@ -137,51 +135,14 @@ func (ofi *OriginatorFI) Format(options FormatOptions) string {
 // The first error encountered is returned and stops that parsing.
 // If ID Code is present, Identifier is mandatory and vice versa.
 func (ofi *OriginatorFI) Validate() error {
-	if err := ofi.fieldInclusion(); err != nil {
-		return err
-	}
 	if ofi.tag != TagOriginatorFI {
 		return fieldError("tag", ErrValidTagForType, ofi.tag)
 	}
 
-	// only validate IdentificationCode if a value was provided, or if it's required due to the presence of an Identifier
-	if ofi.FinancialInstitution.Identifier != "" || ofi.FinancialInstitution.IdentificationCode != "" {
-		// Can only be these Identification Codes
-		switch ofi.FinancialInstitution.IdentificationCode {
-		case
-			"B", "C", "D", "F", "U":
-		default:
-			return fieldError("IdentificationCode", ErrIdentificationCode, ofi.FinancialInstitution.IdentificationCode)
-		}
+	if err := ofi.FinancialInstitution.Validate(); err != nil {
+		return err
 	}
 
-	if err := ofi.isAlphanumeric(ofi.FinancialInstitution.Identifier); err != nil {
-		return fieldError("Identifier", err, ofi.FinancialInstitution.Identifier)
-	}
-	if err := ofi.isAlphanumeric(ofi.FinancialInstitution.Name); err != nil {
-		return fieldError("Name", err, ofi.FinancialInstitution.Name)
-	}
-	if err := ofi.isAlphanumeric(ofi.FinancialInstitution.Address.AddressLineOne); err != nil {
-		return fieldError("AddressLineOne", err, ofi.FinancialInstitution.Address.AddressLineOne)
-	}
-	if err := ofi.isAlphanumeric(ofi.FinancialInstitution.Address.AddressLineTwo); err != nil {
-		return fieldError("AddressLineTwo", err, ofi.FinancialInstitution.Address.AddressLineTwo)
-	}
-	if err := ofi.isAlphanumeric(ofi.FinancialInstitution.Address.AddressLineThree); err != nil {
-		return fieldError("AddressLineThree", err, ofi.FinancialInstitution.Address.AddressLineThree)
-	}
-	return nil
-}
-
-// fieldInclusion validate mandatory fields. If fields are
-// invalid the WIRE will return an error.
-func (ofi *OriginatorFI) fieldInclusion() error {
-	if ofi.FinancialInstitution.IdentificationCode != "" && ofi.FinancialInstitution.Identifier == "" {
-		return fieldError("Identifier", ErrFieldRequired)
-	}
-	if ofi.FinancialInstitution.IdentificationCode == "" && ofi.FinancialInstitution.Identifier != "" {
-		return fieldError("IdentificationCode", ErrFieldRequired)
-	}
 	return nil
 }
 


### PR DESCRIPTION
<!-- Please fill out the following questions, thanks! -->

**What does this pull request do?**
This change combines duplicate `Validate()` funcs from the structs that include `FinancialInstitution` as a field onto the `FinancialInstitution` struct itself.

**What Wire specification are you referencing?**
FAIM 3.0.4

