### PR TITLE
fix: Allow {6100} for CTP, but reject {6110} (matches specification)

### DIFF
--- a/fedWireMessage.go
+++ b/fedWireMessage.go
@@ -618,8 +618,8 @@ func (fwm *FEDWireMessage) checkProhibitedCustomerTransferPlusTags() error {
 	if fwm.AccountCreditedDrawdown != nil {
 		return fieldError("AccountCreditedDrawdown", ErrInvalidProperty, fwm.AccountCreditedDrawdown)
 	}
-	if fwm.FIReceiverFI != nil {
-		return fieldError("FIReceiverFI", ErrInvalidProperty, fwm.FIReceiverFI)
+	if fwm.FIDrawdownDebitAccountAdvice != nil {
+		return fieldError("FIDrawdownDebitAccountAdvice", ErrInvalidProperty, fwm.FIDrawdownDebitAccountAdvice)
 	}
 
 	if fwm.LocalInstrument != nil {


### PR DESCRIPTION

![Screenshot 2024-03-07 at 10 30 24](https://github.com/moov-io/wire/assets/120951/d9025972-2137-4aeb-a5c1-4b5bba4abd14)


See: https://moov-io.slack.com/archives/CJV1WSCKF/p1709756468901419
