### PR TITLE
fix: don't add delmiter on {3600} when typecode is unspecified

### DIFF
--- a/businessFunctionCode.go
+++ b/businessFunctionCode.go
@@ -88,7 +88,12 @@ func (bfc *BusinessFunctionCode) Format(options FormatOptions) string {
 
 	buf.WriteString(bfc.tag)
 	buf.WriteString(bfc.BusinessFunctionCodeField())
-	buf.WriteString(bfc.FormatTransactionTypeCode(options) + Delimiter)
+
+	typeCode := bfc.FormatTransactionTypeCode(options)
+	buf.WriteString(typeCode)
+	if bfc.TransactionTypeCode != "" {
+		buf.WriteString(Delimiter)
+	}
 
 	return buf.String()
 }
@@ -135,8 +140,11 @@ func (bfc *BusinessFunctionCode) TransactionTypeCodeField() string {
 // FormatTransactionTypeCode returns TransactionTypeCode formatted according to the FormatOptions
 func (bfc *BusinessFunctionCode) FormatTransactionTypeCode(options FormatOptions) string {
 	// for variable length and empty TransactionTypeCode, no formatting is needed
-	if options.VariableLengthFields && bfc.TransactionTypeCode == "" {
+	if bfc.TransactionTypeCode == "" {
 		return ""
+	}
+	if options.VariableLengthFields {
+		return bfc.TransactionTypeCode
 	}
 	return bfc.formatAlphaField(bfc.TransactionTypeCode, 3, options)
 }

--- a/businessFunctionCode_test.go
+++ b/businessFunctionCode_test.go
@@ -81,6 +81,17 @@ func TestBusinessFunctionCodeTagError(t *testing.T) {
 	require.EqualError(t, err, fieldError("tag", ErrValidTagForType, bfc.tag).Error())
 }
 
+func TestBusinessFunctionCodeDelimiter(t *testing.T) {
+	bfc := NewBusinessFunctionCode()
+	bfc.BusinessFunctionCode = CustomerTransfer
+	require.Equal(t, "{3600}CTR", bfc.String())
+	require.Equal(t, "{3600}CTR", bfc.Format(FormatOptions{VariableLengthFields: true}))
+
+	bfc.TransactionTypeCode = "23"
+	require.Equal(t, "{3600}CTR23 *", bfc.String())
+	require.Equal(t, "{3600}CTR23*", bfc.Format(FormatOptions{VariableLengthFields: true}))
+}
+
 // TestStringBusinessFunctionCodeVariableLength parses using variable length
 func TestStringBusinessFunctionCodeVariableLength(t *testing.T) {
 	var line = "{3600}"
@@ -123,8 +134,9 @@ func TestStringBusinessFunctionCodeOptions(t *testing.T) {
 	require.Equal(t, err, nil)
 
 	bfc := r.currentFEDWireMessage.BusinessFunctionCode
-	require.Equal(t, bfc.String(), "{3600}BTR   *")
-	require.Equal(t, bfc.Format(FormatOptions{VariableLengthFields: true}), "{3600}BTR*")
-	require.Equal(t, bfc.String(), bfc.Format(FormatOptions{VariableLengthFields: false}))
+	require.Equal(t, "{3600}BTR", bfc.String())
+	require.Equal(t, "{3600}BTR", bfc.Format(FormatOptions{VariableLengthFields: true}))
 
+	require.Equal(t, "{3600}BTR", bfc.Format(FormatOptions{VariableLengthFields: false}))
+	require.Equal(t, bfc.Format(FormatOptions{VariableLengthFields: false}), bfc.String())
 }


### PR DESCRIPTION
Fixes: https://github.com/moov-io/wire/issues/387

