### PR TITLE
Payment Notification is allowed in BankTransfer

### DIFF
--- a/fedWireMessage.go
+++ b/fedWireMessage.go
@@ -401,9 +401,6 @@ func (fwm *FEDWireMessage) checkProhibitedBankTransferTags() error {
 	if fwm.LocalInstrument != nil {
 		return fieldError("LocalInstrument", ErrInvalidProperty, fwm.LocalInstrument)
 	}
-	if fwm.PaymentNotification != nil {
-		return fieldError("PaymentNotification", ErrInvalidProperty, fwm.PaymentNotification)
-	}
 	if fwm.Charges != nil {
 		return fieldError("Charges", ErrInvalidProperty, fwm.Charges)
 	}

--- a/fedWiremessage_test.go
+++ b/fedWiremessage_test.go
@@ -606,20 +606,6 @@ func TestInvalidLocalInstrumentForBankTransfer(t *testing.T) {
 	require.EqualError(t, err, expected)
 }
 
-// TestInvalidPaymentNotificationForBankTransfer test an invalid PaymentNotification
-func TestInvalidPaymentNotificationForBankTransfer(t *testing.T) {
-	fwm := new(FEDWireMessage)
-	bfc := mockBusinessFunctionCode()
-	bfc.BusinessFunctionCode = BankTransfer
-	fwm.BusinessFunctionCode = bfc
-	fwm.PaymentNotification = mockPaymentNotification()
-
-	err := fwm.checkProhibitedBankTransferTags()
-
-	expected := fieldError("PaymentNotification", ErrInvalidProperty, fwm.PaymentNotification).Error()
-	require.EqualError(t, err, expected)
-}
-
 // TestInvalidChargesForBankTransfer test an invalid Charges
 func TestInvalidChargesForBankTransfer(t *testing.T) {
 	fwm := new(FEDWireMessage)


### PR DESCRIPTION
Tag `{3620}` (Payment Notification) is allowed in both BTR and CTP wires.

Closes #453 